### PR TITLE
Refactorings to remove dependencies on Pyramid request objects

### DIFF
--- a/jasmin_portal/ldap.py
+++ b/jasmin_portal/ldap.py
@@ -62,21 +62,25 @@ def ldap_connection(request):
                             password = request.registry.settings['ldap.bind_pass'],
                             auto_bind = ldap3.AUTO_BIND_TLS_BEFORE_BIND,
                             raise_exceptions = True)
-
-
-_char_map = { '*': '\\2A', '(': '\\28', ')': '\\29', '\\': '\\5C', '\0': '\\00' }
-def _escape_filter_param(value):
-    """
-    Escapes a parameter value for use in an LDAP filter.
-    """
-    if isinstance(value, bytes):
-        return ldap3.utils.conv.escape_bytes(value)
-    else:
-        if not isinstance(value, str):
-            value = str(value)
-        return ''.join(_char_map.get(c, c) for c in value)
     
     
+def update_entry(conn, dn, attributes):
+    """
+    Uses the given connection to update the entry with the given DN with the given
+    attributes.
+    
+    Attributes should be a mapping of field name to an iterable (usually a list)
+    of values.
+    
+    :param conn: The LDAP connection to use
+    :param dn: The DN of the entry to update
+    :param attributes: The new values of the attributes
+    :returns: ``True`` on success
+    """
+    # Make sure the correct operation is applied
+    return conn.modify(dn, { k : (ldap3.MODIFY_REPLACE, v) for k, v in attributes })
+
+
 class Filter:
     """
     Represents a filter for an LDAP search query.
@@ -117,16 +121,29 @@ class Filter:
     
         f('uid={}', 'bob') & ( ~f('email=*') | f('gn=*') )
     """
+    __char_map = { '*': '\\2A', '(': '\\28', ')': '\\29', '\\': '\\5C', '\0': '\\00' }
+    
     def __init__(self, filter_str, *args, **kwargs):
         if args or kwargs:
             # Escape the arguments for use in LDAP filters
-            args_e = [ _escape_filter_param(v) for v in args ]
-            kwargs_e = { k: _escape_filter_param(v) for k, v in kwargs.items() }
+            args_e = [ self.__escape_filter_param(v) for v in args ]
+            kwargs_e = { k: self.__escape_filter_param(v) for k, v in kwargs.items() }
             # Interpolate the filter string the escaped values
             self._filter_str = filter_str.format(*args_e, **kwargs_e)
         else:
             self._filter_str = filter_str
         self._filter_str = '(' + self._filter_str + ')'
+    
+    def __escape_filter_param(self, value):
+        """
+        Escapes a parameter value for use in an LDAP filter.
+        """
+        if isinstance(value, bytes):
+            return ldap3.utils.conv.escape_bytes(value)
+        else:
+            if not isinstance(value, str):
+                value = str(value)
+            return ''.join(self.__char_map.get(c, c) for c in value)
         
     def __repr__(self):
         """
@@ -162,11 +179,10 @@ class Query(Iterable):
     time that data is requested. The query result is then cached in memory and
     used for future iterations unless ``execute`` is called again.
     
-    By default, the items returned on iteration will be
-    `ldap3 Entry objects <https://ldap3.readthedocs.org/abstraction.html#entry>`_.
-    However, a transform function can be applied - this function should take
-    an ldap3 Entry and return another object, which will then be returned during
-    iteration.
+    By default, the items returned on iteration will be mappings of field names
+    to arrays of values. However, a transform function can be applied - this
+    function should take a field-to-values mapping and return another object,
+    which will then be returned during iteration.
     
     :param conn: ``ldap3.Connection`` to use
     :param base_dn: DN to use as the base for the LDAP search
@@ -190,6 +206,12 @@ class Query(Iterable):
         self._attrs = attrs
         self._transform = transform
         self._results = None
+        
+    def __map(self, entry):
+        """
+        Takes an LDAP entry, extracts the attributes and dn and applies the transform.
+        """
+        return self._transform(dict(entry['attributes'], dn = entry['dn']))
     
     def execute(self):
         """
@@ -199,7 +221,7 @@ class Query(Iterable):
         """
         self._conn.search(self._base_dn, str(self._filter),
                           search_scope = self._scope, attributes = self._attrs)
-        self._results = list(map(self._transform, self._conn.entries or []))
+        self._results = list(map(self.__map, self._conn.response or []))
         return self
     
     def __iter__(self):

--- a/jasmin_portal/ldap.py
+++ b/jasmin_portal/ldap.py
@@ -18,67 +18,91 @@ def includeme(config):
     
     :param config: Pyramid configurator
     """
+    def ldap_connection(request):
+        return LDAPConnection(request.registry.settings)
     config.add_request_method(ldap_connection, reify = True)
-
-
-def ldap_authenticate(request, user_dn, password):
-    """
-    Attempts to authenticate the user with the given DN and password with the
-    LDAP database specified by the request settings.
     
-    :param request: The Pyramid request
-    :param user_dn: The DN of the user to authenticate
-    :param password: The password to use for authentication
-    :returns: ``True`` on success, ``False`` on failure
+    
+class LDAPConnection:
     """
-    try:
-        ldap3.Connection(request.registry.settings['ldap.server'],
-                         user = user_dn, password = password,
-                         auto_bind = ldap3.AUTO_BIND_TLS_BEFORE_BIND,
-                         raise_exceptions = True).unbind()
-        return True
-    except ldap3.LDAPOperationResult:
-        # If the operation fails, treat that as an auth failure
-        return False
-
-
-def ldap_connection(request):
-    """
-    Opens a connection to the LDAP database specified by the request settings.
+    Class representing an LDAP connection and the operations that can be performed.
     
     .. note::
     
-        This function should be accessed as a property of the Pyramid request object,
-        i.e. ``conn = request.ldap_connection``.
+        An instance of this class can be accessed as a property of the Pyramid
+        request object, i.e. ``r = request.ldap_connection``.
        
-        This property is reified, so there is only one LDAP connection per request.
-       
-    :param request: The Pyramid request
-    :returns: An LDAP connection
-    :rtype: ``ldap3.Connection``
+        This property is reified, so it is only evaluated once per request.
     """
-    return ldap3.Connection(request.registry.settings['ldap.server'],
-                            user = request.registry.settings['ldap.bind_dn'],
-                            password = request.registry.settings['ldap.bind_pass'],
-                            auto_bind = ldap3.AUTO_BIND_TLS_BEFORE_BIND,
-                            raise_exceptions = True)
+    def __init__(self, settings):
+        self._settings = settings
+        # The underlying ldap3 connection is opened the first time it is requested
+        self._conn = None
+
+    def authenticate(self, user_dn, password):
+        """
+        Attempts to authenticate the user with the given DN and password with the
+        LDAP database specified by the settings given in the constructor.
+        
+        :param user_dn: The DN of the user to authenticate
+        :param password: The password to use for authentication
+        :returns: ``True`` on success, ``False`` on failure
+        """
+        try:
+            ldap3.Connection(
+                self._settings['ldap.server'],
+                user = user_dn, password = password,
+                auto_bind = ldap3.AUTO_BIND_TLS_BEFORE_BIND,
+                raise_exceptions = True
+            ).unbind()
+            return True
+        except ldap3.LDAPOperationResult:
+            # If the operation fails, treat that as an auth failure
+            return False
+
+    def __connection(self):
+        """
+        Returns an open connection to the LDAP database, creating it if it is
+        not already open.
+        """
+        if self._conn is None:
+            self._conn = ldap3.Connection(
+                self._settings['ldap.server'],
+                user = self._settings['ldap.bind_dn'],
+                password = self._settings['ldap.bind_pass'],
+                auto_bind = ldap3.AUTO_BIND_TLS_BEFORE_BIND,
+                raise_exceptions = True
+            )
+        return self._conn
     
+    def create_query(self, base_dn, filter, transform = lambda x: x):
+        """create_query(base_dn, filter, transform = lambda x: x)
     
-def update_entry(conn, dn, attributes):
-    """
-    Uses the given connection to update the entry with the given DN with the given
-    attributes.
+        Creates a new :py:class:`Query` using this connection.
+        
+        :param base_dn: DN to use as the base for the LDAP search
+        :param filter: :py:class:`Filter` to use for the search
+        :param transform: Transform function to use
+        :returns: A :py:class:`Query` object
+        """
+        return Query(self.__connection(), base_dn, filter, transform)
     
-    Attributes should be a mapping of field name to an iterable (usually a list)
-    of values.
-    
-    :param conn: The LDAP connection to use
-    :param dn: The DN of the entry to update
-    :param attributes: The new values of the attributes
-    :returns: ``True`` on success
-    """
-    # Make sure the correct operation is applied
-    return conn.modify(dn, { k : (ldap3.MODIFY_REPLACE, v) for k, v in attributes })
+    def update_entry(self, dn, attributes):
+        """
+        Uses this connection to update the entry with the given DN with the given
+        attributes.
+        
+        Attributes should be a mapping of field name to an iterable (usually a list)
+        of values.
+        
+        :param dn: The DN of the entry to update
+        :param attributes: The new values of the attributes
+        :returns: ``True`` on success
+        """
+        # Make sure the correct operation is applied
+        return self.__connection().modify(
+            dn, { k : (ldap3.MODIFY_REPLACE, v) for k, v in attributes }
+        )
 
 
 class Filter:
@@ -171,7 +195,7 @@ class Filter:
 
 
 class Query(Iterable):
-    """Query(conn, base_dn, filter, scope = ldap3.SEARCH_SCOPE_SINGLE_LEVEL, attrs = ldap3.ALL_ATTRIBUTES, transform = lambda x: x)
+    """Query(conn, base_dn, filter, transform = lambda x: x)
     
     Represents an LDAP search query.
     
@@ -187,23 +211,12 @@ class Query(Iterable):
     :param conn: ``ldap3.Connection`` to use
     :param base_dn: DN to use as the base for the LDAP search
     :param filter: Filter to use for the search
-    :param scope: Scope for the search (see
-                  `the ldap3 docs <https://ldap3.readthedocs.org/searches.html>`_
-                  for allowed values)
-    :param attrs: Attributes to return during the search (see
-                  `the ldap3 docs <https://ldap3.readthedocs.org/searches.html>`_
-                  for allowed values)
     :param transform: Transform function to use
     """
-    def __init__(self, conn, base_dn, filter, 
-                       scope = ldap3.SEARCH_SCOPE_SINGLE_LEVEL,
-                       attrs = ldap3.ALL_ATTRIBUTES,
-                       transform = lambda x: x):
+    def __init__(self, conn, base_dn, filter, transform = lambda x: x):
         self._conn = conn
         self._base_dn = base_dn
         self._filter = filter
-        self._scope = scope
-        self._attrs = attrs
         self._transform = transform
         self._results = None
         
@@ -220,7 +233,8 @@ class Query(Iterable):
         :returns: ``self``
         """
         self._conn.search(self._base_dn, str(self._filter),
-                          search_scope = self._scope, attributes = self._attrs)
+                          search_scope = ldap3.SEARCH_SCOPE_SINGLE_LEVEL,
+                          attributes = ldap3.ALL_ATTRIBUTES)
         self._results = list(map(self.__map, self._conn.response or []))
         return self
     

--- a/jasmin_portal/ldap.py
+++ b/jasmin_portal/ldap.py
@@ -33,6 +33,8 @@ class LDAPConnection:
         request object, i.e. ``r = request.ldap_connection``.
        
         This property is reified, so it is only evaluated once per request.
+        
+    :param settings: The settings dictionary
     """
     def __init__(self, settings):
         self._settings = settings
@@ -101,7 +103,7 @@ class LDAPConnection:
         """
         # Make sure the correct operation is applied
         return self.__connection().modify(
-            dn, { k : (ldap3.MODIFY_REPLACE, v) for k, v in attributes }
+            dn, { k : (ldap3.MODIFY_REPLACE, v) for k, v in attributes.items() }
         )
 
 

--- a/jasmin_portal/util.py
+++ b/jasmin_portal/util.py
@@ -11,6 +11,18 @@ from functools import reduce
 from collections import Iterable
 
 
+def first(iterable, default):
+    """
+    Returns the first element of the iterable if it is non-empty, or the given
+    default if it is empty.
+    
+    :param iterable: The iterable to get the first element of
+    :param default: The default value to return if the iterable is empty
+    :returns: The first element of iterable or default
+    """
+    return next(iter(iterable), default)
+    
+
 def getattrs(obj, attrs, default):
     """
     Similar to ``getattr``, but allows a list of attribute names to be resolved


### PR DESCRIPTION
This pull request just implements some refactoring to remove depdencies on the actual Pyramid request from objects that really only need a few settings or another non-Pyramid object.