### PR TITLE
Improve vCD error reporting

### DIFF
--- a/jasmin_cloud/cloudservices/__init__.py
+++ b/jasmin_cloud/cloudservices/__init__.py
@@ -176,22 +176,6 @@ class Machine(namedtuple('MachineProps', ['id', 'name', 'status',
     """
 
     
-class Provider(metaclass = abc.ABCMeta):
-    """
-    Abstract base for a cloud service provider. 
-    """
-    
-    @abc.abstractmethod
-    def new_session(self, username, password):
-        """
-        Create a new session for the provider using the given credentials.
-        
-        :param username: The cloud service username
-        :param password: The cloud service password
-        :returns: The authenticated :py:class:`Session`
-        """
-        
-
 class Session(metaclass = abc.ABCMeta):
     """
     Abstract base class for an authenticated session with a cloud provider,
@@ -203,8 +187,7 @@ class Session(metaclass = abc.ABCMeta):
     
     ::
     
-        p = VCloudProvider("https://vcloud.myexample.com/api")
-        with p.new_session("user@org", "pass") as s:
+        with VCloudSession("https://vcloud.myexample.com/api", "user@org", "pass") as s:
             m = s.provision_machine(...)
             s.start_machine(m.id)
     """

--- a/jasmin_cloud/cloudservices/exceptions.py
+++ b/jasmin_cloud/cloudservices/exceptions.py
@@ -1,8 +1,5 @@
 """
 This module defines the exceptions that can be thrown by cloud operations.
-
-A lot of the time, errors will be raised with a :py:class:`ProviderSpecificError`
-as the cause, i.e. using the ``raise ... from ...`` syntax.
 """
 
 __author__ = "Matt Pryor"
@@ -17,9 +14,6 @@ class ProviderConnectionError(CloudServiceError):
     
 class ProviderUnavailableError(CloudServiceError):
     """Thrown when a provider connects but reports an error."""
-    
-class ProviderSpecificError(CloudServiceError):
-    """Base class for provider specific errors."""
     
 class ImplementationError(CloudServiceError):
     """Thrown when an error occurs in the implementation or the implementation

--- a/jasmin_cloud/cloudservices/exceptions.py
+++ b/jasmin_cloud/cloudservices/exceptions.py
@@ -1,5 +1,8 @@
 """
 This module defines the exceptions that can be thrown by cloud operations.
+
+A lot of the time, errors will be raised with a :py:class:`ProviderSpecificError`
+as the cause, i.e. using the ``raise ... from ...`` syntax.
 """
 
 __author__ = "Matt Pryor"
@@ -14,6 +17,9 @@ class ProviderConnectionError(CloudServiceError):
     
 class ProviderUnavailableError(CloudServiceError):
     """Thrown when a provider connects but reports an error."""
+    
+class ProviderSpecificError(CloudServiceError):
+    """Base class for provider specific errors."""
     
 class ImplementationError(CloudServiceError):
     """Thrown when an error occurs in the implementation or the implementation

--- a/jasmin_cloud/cloudservices/exceptions.py
+++ b/jasmin_cloud/cloudservices/exceptions.py
@@ -61,3 +61,12 @@ class NetworkingError(CloudServiceError):
 class PowerActionError(CloudServiceError):
     """Thrown when an error occurs while performing a power action on a VM."""
     
+class TaskFailedError(CloudServiceError):
+    """Thrown when a long running task fails."""
+    
+class TaskCancelledError(TaskFailedError):
+    """Thrown when a task fails due to being cancelled by a user."""
+    
+class TaskAbortedError(TaskFailedError):
+    """Thrown when a task fails due to being aborted by an administrator."""
+    

--- a/jasmin_cloud/templates/layout.jinja2
+++ b/jasmin_cloud/templates/layout.jinja2
@@ -96,20 +96,17 @@
                     <div class="row">
                         <div class="col-md-6 col-md-offset-3">
                             {%- for message in request.session.pop_flash('success') %}
-                                <div class="alert alert-success alert-dismissible" role="alert">
-                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                                <div class="alert alert-success" role="alert">
                                     <i class="fa fa-check-circle"></i> <span>{{ message }}</span>
                                 </div>
                             {%- endfor %}
                             {%- for message in request.session.pop_flash('error') %}
-                                <div class="alert alert-danger alert-dismissible" role="alert">
-                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                                <div class="alert alert-danger" role="alert">
                                     <i class="fa fa-exclamation-circle"></i> <span>{{ message }}</span>
                                 </div>
                             {%- endfor %}
                             {%- for message in request.session.pop_flash('info') %}
-                                <div class="alert alert-info alert-dismissible" role="alert">
-                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                                <div class="alert alert-info" role="alert">
                                     <i class="fa fa-info-circle"></i> <span>{{ message }}</span>
                                 </div>
                             {%- endfor %}

--- a/jasmin_cloud/views.py
+++ b/jasmin_cloud/views.py
@@ -5,6 +5,8 @@ This module contains Pyramid view callables for the JASMIN cloud portal.
 __author__ = "Matt Pryor"
 __copyright__ = "Copyright 2015 UK Science and Technology Facilities Council"
 
+import logging
+
 from pyramid.view import view_config, forbidden_view_config, notfound_view_config
 from pyramid.security import remember, forget
 from pyramid.session import check_csrf_token
@@ -14,6 +16,9 @@ from . import cloudservices
 from .cloudservices import NATPolicy
 from .cloudservices.vcloud import VCloudSession
 from .util import validate_ssh_key
+
+
+_log = logging.getLogger(__name__)
 
 
 ################################################################################
@@ -66,21 +71,23 @@ def notfound(request):
 
 
 @view_config(context = cloudservices.CloudServiceError)
-def cloud_service_error(context, request):
+def cloud_service_error(ctx, request):
     """
     Handler for cloud service errors.
     
-    Shows a suitable error on the most specific page possible.
+    If the error is an "expected" error (e.g. not found, permissions), then convert
+    to the HTTP equivalent.
+    
+    Otherwise, show a suitable error on the most specific page possible and log
+    the complete error for sysadmins.
     """
-    # Convert some cloud service errors into their HTTP equivalents
-    if isinstance(context, (cloudservices.AuthenticationError,
-                            cloudservices.PermissionsError)):
+    if isinstance(ctx, (cloudservices.AuthenticationError,
+                        cloudservices.PermissionsError)):
         return forbidden(request)
-    if isinstance(context, cloudservices.NoSuchResourceError):
+    if isinstance(ctx, cloudservices.NoSuchResourceError):
         return notfound(request)
-    # For other cloud service errors, just add their text to the error flash
-    # and redirect
-    request.session.flash(str(context), 'error')
+    request.session.flash("{}: {}".format(ctx.__class__.__name__, ctx), 'error')
+    _log.error('Unhandled cloud service error', exc_info=(type(ctx), ctx, ctx.__traceback__))
     return _exception_redirect(request)
 
 
@@ -139,10 +146,9 @@ def login(request):
                         request.registry.settings['vcloud.endpoint'],
                         '{}@{}'.format(username, org), password
                     )
-            except cloudservices.CloudServiceError as e:
+            except cloudservices.CloudServiceError:
                 request.cloud_sessions.clear()
-                request.session.flash(str(e), 'error')
-                return {}
+                raise
             # When a user logs in successfully, force a refresh of the CSRF token
             request.session.new_csrf_token()
             return HTTPSeeOther(location = request.route_url('dashboard'),
@@ -387,15 +393,11 @@ def new_machine(request):
             request.session.flash('There are errors with one or more fields', 'error')
             machine_info['errors']['name'] = ['Machine name is already in use']
             return machine_info
-        except (cloudservices.BadRequestError,
-                cloudservices.ProvisioningError) as e:
-            # If provisioning fails, we want to report an error
-            request.session.flash('Provisioning error: {}'.format(str(e)), 'error')
-        except cloudservices.NetworkingError as e:
+        except cloudservices.NetworkingError:
             # Networking doesn't happen until the machine has been provisioned
-            # So we report that provisioning was successful but networking failed
+            # So we report that provisioning was successful before propagating
             request.session.flash('Machine provisioned successfully', 'success')
-            request.session.flash('Networking error: {}'.format(str(e)), 'error')
+            raise
         # If we get this far, redirect to machines
         return HTTPSeeOther(location = request.route_url('machines'))
     # Only get requests should get this far

--- a/jasmin_cloud/views.py
+++ b/jasmin_cloud/views.py
@@ -86,7 +86,7 @@ def cloud_service_error(ctx, request):
         return forbidden(request)
     if isinstance(ctx, cloudservices.NoSuchResourceError):
         return notfound(request)
-    request.session.flash("{}: {}".format(ctx.__class__.__name__, ctx), 'error')
+    request.session.flash(str(ctx), 'error')
     _log.error('Unhandled cloud service error', exc_info=(type(ctx), ctx, ctx.__traceback__))
     return _exception_redirect(request)
 

--- a/jasmin_cloud/views.py
+++ b/jasmin_cloud/views.py
@@ -12,7 +12,7 @@ from pyramid.httpexceptions import HTTPSeeOther, HTTPBadRequest
 
 from . import cloudservices
 from .cloudservices import NATPolicy
-from .cloudservices.vcloud import VCloudProvider
+from .cloudservices.vcloud import VCloudSession
 from .util import validate_ssh_key
 
 
@@ -134,10 +134,11 @@ def login(request):
             # Try to create a session for each of the user's orgs
             # If any of them fail, bail with the error message
             try:
-                provider = VCloudProvider(request.registry.settings['vcloud.endpoint'])
                 for org in request.memberships.orgs_for_user(username):
-                    session = provider.new_session('{}@{}'.format(username, org), password)
-                    request.cloud_sessions[org] = session
+                    request.cloud_sessions[org] = VCloudSession(
+                        request.registry.settings['vcloud.endpoint'],
+                        '{}@{}'.format(username, org), password
+                    )
             except cloudservices.CloudServiceError as e:
                 request.cloud_sessions.clear()
                 request.session.flash(str(e), 'error')


### PR DESCRIPTION
Improves the reporting of errors from vCloud Director.

Introduces a new nested exception structure using `raise ... from ...` where the lowest level exception encapsulated the actual vCD error.

Unhandled cloud exceptions are logged with a full stack trace, but a sensible message is presented to the user