### PR TITLE
Restrict template creation using vCD metadata

### DIFF
--- a/jasmin_cloud/cloud.py
+++ b/jasmin_cloud/cloud.py
@@ -13,13 +13,8 @@ def includeme(config):
     
     :param config: Pyramid configurator
     """
-    # Expose a key in the session array as storage for our sessions
-    SESSION_KEY = 'cloud'
-    def cloud_sessions(request):
-        if SESSION_KEY not in request.session:
-            request.session[SESSION_KEY] = {}
-        return request.session[SESSION_KEY]
     config.add_request_method(cloud_sessions, reify = True)
+    config.add_request_method(active_cloud_session, reify = True)
     
     
 _SESSION_KEY = 'cloud'
@@ -37,3 +32,18 @@ def cloud_sessions(request):
     if _SESSION_KEY not in request.session:
         request.session[_SESSION_KEY] = {}
     return request.session[_SESSION_KEY]
+
+
+def active_cloud_session(request):
+    """
+    Returns the cloud session for the current org, or ``None`` if there is not one.
+    
+    .. note::
+    
+        This function should be accessed as a property of the Pyramid request object,
+        i.e. ``sessions = request.active_cloud_session``.
+       
+        This property is reified, so it is only evaluated once per request.
+    """
+    return request.cloud_sessions.get(request.current_org, None)
+    

--- a/jasmin_cloud/cloudservices/__init__.py
+++ b/jasmin_cloud/cloudservices/__init__.py
@@ -219,6 +219,15 @@ class Session(metaclass = abc.ABCMeta):
         
         :returns: True on success
         """
+        
+    @abc.abstractmethod
+    def has_permission(self, permission):
+        """
+        Tests whether the session has the given permission.
+        
+        :param permission: The permission to test for
+        :returns: ``True`` if the session has the permission, ``False`` otherwise
+        """
     
     @abc.abstractmethod
     def list_images(self):

--- a/jasmin_cloud/cloudservices/vcloud/__init__.py
+++ b/jasmin_cloud/cloudservices/vcloud/__init__.py
@@ -342,6 +342,20 @@ class VCloudSession(Session):
         # Just hit an API endpoint that does nothing but report session info
         self.api_request('GET', 'session')
         return True
+        
+    def has_permission(self, permission):
+        """
+        See :py:meth:`jasmin_cloud.cloudservices.Session.has_permission`.
+        """
+        # This implementation uses vCD metadata attached to the org
+        # So first, we get the href of the org for the session
+        session = ET.fromstring(self.api_request('GET', 'session').text)
+        org = session.find('.//vcd:Link[@type="application/vnd.vmware.vcloud.org+xml"]', _NS)
+        # Then get the metadata
+        meta = self.get_metadata(org.attrib['href'])
+        # Add the namespace to the permission as the key into metadata
+        #   If the key is not present, treat that as having value 0
+        return bool(meta.get('JASMIN.{}'.format(permission.upper()), 0))
             
     def list_images(self):
         """

--- a/jasmin_cloud/cloudservices/vcloud/__init__.py
+++ b/jasmin_cloud/cloudservices/vcloud/__init__.py
@@ -434,7 +434,10 @@ class VCloudSession(Session):
         
             This implementation uses `vAppTemplate` uuids as the image ids
         """
-        # First, find the catalogue we will create the image in
+        # First, check if the session is allowed to do this!
+        if not self.has_permission('CAN_CREATE_TEMPLATES'):
+            raise PermissionsError('Insufficient permissions')
+        # Find the catalogue we will create the image in
         # This is done by selecting the first catalogue from the org we are using
         # First, we have to retrieve the org from the session
         session = ET.fromstring(self.api_request('GET', 'session').text)

--- a/jasmin_cloud/membership.py
+++ b/jasmin_cloud/membership.py
@@ -121,7 +121,7 @@ class MembershipManager:
         # We want to use the cn for the organisation name
         cns = (e['attributes']['cn'][0].lower() for e in (self.__conn.response or []))
         # We want to remove the suffix
-        return [cn.replace(self.__group_suffix, '') for cn in cns]
+        return sorted([cn.replace(self.__group_suffix, '') for cn in cns])
         
     def members_for_org(self, organisation):
         """

--- a/jasmin_cloud/templates/machines.jinja2
+++ b/jasmin_cloud/templates/machines.jinja2
@@ -52,15 +52,17 @@
                     <td><code>{{ machine.external_ip|default('-', true) }}</code></td>
                     <td>{{ machine.created.strftime('%Y-%m-%d %H:%M:%S') }}</td>
                     <td style="white-space : nowrap;">
-                        <a class="btn btn-default btn-xs confirm" title="Add to catalogue"
-                           data-confirm-message="<p>Ensure you have run <code>/root/vappclean.sh</code>
-                                                 to prepare the machine for the catalogue before proceeding.</p>
-                                                 <p>This will render the machine unusable for anything other
-                                                 than adding to the catalogue.</p>"
-                           href="{{ request.route_url('catalogue_new', id = machine.id) }}">
-                            <i class="fa fa-fw fa-book"></i>
-                            <span class="sr-only">Add to catalogue</span>
-                        </a>
+                        {%- if request.active_cloud_session.has_permission('CAN_CREATE_TEMPLATES') %}
+                            <a class="btn btn-default btn-xs confirm" title="Add to catalogue"
+                               data-confirm-message="<p>Ensure you have run <code>/root/vappclean.sh</code>
+                                                     to prepare the machine for the catalogue before proceeding.</p>
+                                                     <p>This will render the machine unusable for anything other
+                                                     than adding to the catalogue.</p>"
+                               href="{{ request.route_url('catalogue_new', id = machine.id) }}">
+                                <i class="fa fa-fw fa-book"></i>
+                                <span class="sr-only">Add to catalogue</span>
+                            </a>
+                        {%- endif %}
                         <form class="disable-on-submit power-action" autocomplete="off" method="POST"
                               action="{{ request.route_url('machine_action', id = machine.id) }}">
                             <input name="action" type="hidden" value="start" />

--- a/jasmin_cloud/test/test_vcd_provider.py
+++ b/jasmin_cloud/test/test_vcd_provider.py
@@ -54,6 +54,9 @@ class TestVcdProvider(unittest.TestCase, IntegrationTest):
         """
         self.session = VCloudSession(settings.endpoint, settings.username, settings.password)
         self.assertTrue(self.session.poll())
+        # Check that the session has the ability to create templates, or the test
+        # will fail later
+        self.assertTrue(self.session.has_permission('CAN_CREATE_TEMPLATES'))
         
     def get_known_image(self, notused):
         """


### PR DESCRIPTION
This ticket implements a simple method of querying permissions for a cloud session, and an implementation for vCD using metadata attached to the org.

The only permission currently recognised is CAN_CREATE_TEMPLATES, which restricts the creation of templates on a per-org basis.