### PR TITLE
Fix guest customisation escaping

### DIFF
--- a/jasmin_cloud/auth.py
+++ b/jasmin_cloud/auth.py
@@ -148,6 +148,13 @@ def _check_cloud_sessions(userid, request):
         return None
     # Get the user's orgs
     orgs = request.memberships.orgs_for_user(userid)
+    # Get the orgs for which we have sessions
+    session_orgs = request.cloud_sessions.has_sessions_for()
+    # If the two differ, force the user to log in again so that we can log them
+    # in to any new orgs and make sure they are NOT logged in to any that they
+    # can no longer access
+    if set(orgs).symmetric_difference(session_orgs):
+        return None
     # Bail if any sessions that were successfully started have now timed out
     for org in orgs:
         # If this raises, the session was never successfully started

--- a/jasmin_cloud/cloud.py
+++ b/jasmin_cloud/cloud.py
@@ -62,6 +62,12 @@ class CloudSessionManager:
     def __init__(self, sessions):
         self.sessions = sessions
 
+    def has_sessions_for(self):
+        """
+        Returns the orgs for which the cloud session manager has a session.
+        """
+        return self.sessions.keys()
+
     def start_session(self, org, provider, *args, **kwargs):
         """
         Starts a session using the given provider, catching any cloud service errors

--- a/jasmin_cloud/cloudservices/vcloud/ComposeVAppParams.xml
+++ b/jasmin_cloud/cloudservices/vcloud/ComposeVAppParams.xml
@@ -43,7 +43,7 @@
                 <AdminPasswordEnabled>false</AdminPasswordEnabled>
                 <AdminAutoLogonEnabled>false</AdminAutoLogonEnabled>
                 <AdminAutoLogonCount>0</AdminAutoLogonCount>
-                <CustomizationScript>{{ vm.customisation }}</CustomizationScript>
+                <CustomizationScript><![CDATA[{{ vm.customisation }}]]></CustomizationScript>
                 <ComputerName>{{ vm.name }}</ComputerName>
             </GuestCustomizationSection>
         </InstantiationParams>

--- a/jasmin_cloud/cloudservices/vcloud/__init__.py
+++ b/jasmin_cloud/cloudservices/vcloud/__init__.py
@@ -58,12 +58,6 @@ _ENV = Environment(
 # Logger
 _log = logging.getLogger(__name__)
 
-# Function to escape special chars in guest customisation script for XML
-_escape_script = lambda s: s.replace(os.linesep, '&#13;').\
-                             replace('"', '&quot;').\
-                             replace('%', '&#37;').\
-                             replace("'", '&apos;')
-
 
 ###############################################################################
 ###############################################################################
@@ -747,12 +741,12 @@ fi
             # Get a unique name for the VM
             vm_name = uuid.uuid4().hex
             # Make sure the guest customisation script is escaped after formatting
-            script = _escape_script(self._GUEST_CUSTOMISATION.format(
+            script = self._GUEST_CUSTOMISATION.format(
                 ssh_key  = ssh_key.strip(),
                 org_name = org.attrib['name'],
                 vm_type  = image.host_type,
                 vm_id    = vm_name,
-            ))
+            )
             vm_configs.append({
                 'href'          : vm.attrib['href'],
                 'name'          : vm_name,


### PR DESCRIPTION
This pull fixes two problems, one which was discovered while fixing the other:

  * The escaping of guest customisation containing SSH keys with "long-form" email addresses (e.g. `Matt Pryor <matt.pryor@stfc.ac.uk>`)
  * 500 errors when a user's LDAP groups are changed while they are logged in - they are now forced to re-authenticate and the new groups are used