### PR TITLE
Option to prevent adding a disk

### DIFF
--- a/jasmin_cloud/cloudservices/vcloud/__init__.py
+++ b/jasmin_cloud/cloudservices/vcloud/__init__.py
@@ -1053,7 +1053,10 @@ fi
         """
         See :py:meth:`jasmin_cloud.cloudservices.Session.add_disk_to_machine`.
         """
-        # First, check that the machine if off
+        # First, check if the session is allowed to do this!
+        if not self.has_permission('CAN_ADD_DISK'):
+            raise PermissionsError('Insufficient permissions')
+        # Check that the machine if off
         if self.get_machine(machine_id).status != MachineStatus.POWERED_OFF:
             raise InvalidActionError('Machine must be powered off to add a disk')
         # We will work with the first VM in the vApp

--- a/jasmin_cloud/templates/faqs.jinja2
+++ b/jasmin_cloud/templates/faqs.jinja2
@@ -348,6 +348,32 @@ none                         100M     0  100M   0% /run/user
                 Once the template has been created, it will be available to select in the catalogue for your tenancy.
             </p>
         </section>
+
+        <section>
+            <header id="add-disk-disabled">
+                <a class="pull-right" href="#" title="Back to top"><i class="fa fa-caret-up"></i> Back to top</a>
+                <h3>Why is adding a hard disk disabled for my tenancy?</h3>
+            </header>
+
+            <p>
+                Adding a disk is not allowed for tenancies in the Managed Cloud.
+            </p>
+
+            <p>
+                In order to do anything useful with a newly-added disk, such as partition, format or mount it,
+                root access is required. Users are not permitted root access in the managed cloud, due to the
+                Platform-as-a-Service (PaaS) nature of the offering.
+            </p>
+
+            <p>
+                The main reason for having a tenancy in the Managed Cloud is to exploit the high-performance
+                Panasas filesystem that is available, either via a
+                <a href="http://jasmin.ac.uk/how-to-use-jasmin/group-workspaces/working-with-data/">Group Workspace</a>,
+                utilising data in the <a href="http://jasmin.ac.uk/how-to-use-jasmin/group-workspaces/ceda-archives/">CEDA Archives</a>,
+                or both. If you find yourself needing a large local disk, you should consider whether parts of your
+                workload can be moved into the unmanaged cloud.
+            </p>
+        </section>
     </div>
 </div>
 

--- a/jasmin_cloud/templates/machines.jinja2
+++ b/jasmin_cloud/templates/machines.jinja2
@@ -191,25 +191,31 @@
                                         <td></td>
                                     </tr>
                                 <% }); %>
-                                <tr>
-                                    <td style="white-space : nowrap; vertical-align : middle;">
-                                        <label for="disk-size">Add a new disk</label>
-                                    </td>
-                                    <td>
-                                        <div class="form-group">
-                                            <div class="input-group">
-                                                <input class="form-control" name="disk-size" type="number" min="1" step="1" placeholder="Size of disk" required />
-                                                <div class="input-group-addon">GB</div>
+                                {% if request.active_cloud_session.has_permission('CAN_ADD_DISK') %}
+                                    <tr>
+                                        <td style="white-space : nowrap; vertical-align : middle;">
+                                            <label for="disk-size">Add a new disk</label>
+                                        </td>
+                                        <td>
+                                            <div class="form-group">
+                                                <div class="input-group">
+                                                    <input class="form-control" name="disk-size" type="number" min="1" step="1" placeholder="Size of disk" required />
+                                                    <div class="input-group-addon">GB</div>
+                                                </div>
                                             </div>
-                                        </div>
-                                    </td>
-                                    <td>
-                                        <button title="Add disk" type="submit" class="btn btn-success">
-                                            <i class="fa fa-fw fa-plus"></i>
-                                            <span class="sr-only">Add disk</span>
-                                        </button>
-                                    </td>
-                                </tr>
+                                        </td>
+                                        <td>
+                                            <button title="Add disk" type="submit" class="btn btn-success">
+                                                <i class="fa fa-fw fa-plus"></i>
+                                                <span class="sr-only">Add disk</span>
+                                            </button>
+                                        </td>
+                                    </tr>
+                                {% else %}
+                                    <tr>
+                                        <td colspan="3" class="text-muted">Adding a hard disk is disabled for this tenancy.</td>
+                                    </tr>
+                                {% endif %}
                             </tbody>
                         </table>
                     </form>

--- a/jasmin_cloud/test/test_vcd_provider.py
+++ b/jasmin_cloud/test/test_vcd_provider.py
@@ -53,9 +53,10 @@ class TestVcdProvider(unittest.TestCase, IntegrationTest):
         """
         self.session = VCloudSession(settings.endpoint, settings.username, settings.password)
         self.assertTrue(self.session.poll())
-        # Check that the session has the ability to create templates, or the test
-        # will fail later
+        # Check that the session has the ability to create templates and add disk,
+        # or the test will fail later
         self.assertTrue(self.session.has_permission('CAN_CREATE_TEMPLATES'))
+        self.assertTrue(self.session.has_permission('CAN_ADD_DISK'))
 
     def get_known_image(self, notused):
         """

--- a/jasmin_cloud/views.py
+++ b/jasmin_cloud/views.py
@@ -481,6 +481,9 @@ def machine_add_disk(request):
     """
     # Request must pass a CSRF test
     check_csrf_token(request)
+    # Check if the session has permission to create templates
+    if not request.active_cloud_session.has_permission('CAN_ADD_DISK'):
+        raise HTTPForbidden()
     try:
         disk_size = int(request.params['disk-size'])
         if disk_size < 1:


### PR DESCRIPTION
This pull request adds the usage of another org-level permission, `CAN_ADD_DISK`, to determine whether adding a disk is allowed for an org.