### PR TITLE
Add backdoor port annotations for MCP

### DIFF
--- a/jasmin_cloud/authentication.py
+++ b/jasmin_cloud/authentication.py
@@ -1,0 +1,47 @@
+"""
+Django REST Framwork authentication backend for the jasmin_cloud app.
+"""
+
+from rest_framework.authentication import BaseAuthentication
+from rest_framework.exceptions import AuthenticationFailed
+
+from .provider import errors
+from .settings import cloud_settings
+
+
+class AuthenticatedUser:
+    """
+    Fake user that is returned to represent an authenticated user
+    """
+    def __init__(self, username):
+        self.username = username
+        self.is_authenticated = True
+
+    def __str__(self):
+        return self.username
+
+
+class TokenCookieAuthentication(BaseAuthentication):
+    """
+    Authentication backend that uses a token cookie for authentication.
+    """
+    def authenticate(self, request):
+        # First, see if the token cookie is set
+        token = request.get_signed_cookie(cloud_settings.TOKEN_COOKIE_NAME, None)
+        # If it is not, we are done
+        if not token:
+            return None
+        # If there is a token, try to resolve a session with the configured provider
+        # This session will be returned as the auth object
+        try:
+            session = cloud_settings.PROVIDER.from_token(token)
+        except errors.AuthenticationError as exc:
+            # If a session cannot be resolved from the token, then it has expired
+            raise AuthenticationFailed(str(exc))
+        else:
+            # If the token resolved, return an authenticated user
+            return (AuthenticatedUser(session.username()), session)
+
+    def authenticate_header(self, request):
+        # Use "Cookie" as the www-authenticate header
+        return "Cookie"

--- a/jasmin_cloud/middleware.py
+++ b/jasmin_cloud/middleware.py
@@ -11,20 +11,10 @@ def provider_session(get_response):
     Middleware to inject a cloud provider session onto the request based on a token in a cookie.
     """
     def middleware(request):
-        # First, see if the token cookie is set
-        token = request.get_signed_cookie(cloud_settings.TOKEN_COOKIE_NAME, None)
-        if token:
-            try:
-                # If there is a token, try to resolve a session with the configured provider
-                # Set the resolved session as a request property
-                request.provider_session = cloud_settings.PROVIDER.from_token(token)
-            except errors.AuthenticationError as e:
-                # If a session cannot be resolved from the token, do nothing
-                pass
-        # Defer to the next middleware for a response
+        # First, process the request
         response = get_response(request)
         # See if there is a session on the request after the view has run
-        session = getattr(request, 'provider_session', None)
+        session = getattr(request, 'auth', None)
         if session:
             # If there is an open session, set the token cookie and close it
             response.set_signed_cookie(
@@ -38,6 +28,5 @@ def provider_session(get_response):
         else:
             # If there is not a session, delete the cookie
             response.delete_cookie(cloud_settings.TOKEN_COOKIE_NAME)
-        # And we are done
         return response
     return middleware

--- a/jasmin_cloud/middleware.py
+++ b/jasmin_cloud/middleware.py
@@ -25,8 +25,5 @@ def provider_session(get_response):
                 samesite = 'Strict'
             )
             session.close()
-        else:
-            # If there is not a session, delete the cookie
-            response.delete_cookie(cloud_settings.TOKEN_COOKIE_NAME)
         return response
     return middleware

--- a/jasmin_cloud/middleware.py
+++ b/jasmin_cloud/middleware.py
@@ -30,7 +30,7 @@ def provider_session(get_response):
             response.set_signed_cookie(
                 cloud_settings.TOKEN_COOKIE_NAME,
                 session.token(),
-                secure = True,
+                secure = cloud_settings.TOKEN_COOKIE_SECURE,
                 httponly = True,
                 samesite = 'Strict'
             )

--- a/jasmin_cloud/provider/base.py
+++ b/jasmin_cloud/provider/base.py
@@ -62,6 +62,7 @@ class UnscopedSession:
         Returns:
             A string username.
         """
+        raise NotImplementedError
 
     def tenancies(self):
         """

--- a/jasmin_cloud/provider/cluster_engine/awx/api.py
+++ b/jasmin_cloud/provider/cluster_engine/awx/api.py
@@ -2,283 +2,120 @@
 Module containing helpers for interacting with the AWX API.
 """
 
+import copy
+
 import requests
-import logging
+
+import rackit
 
 
-logger = logging.getLogger(__name__)
-
-
-class Error(RuntimeError):
-    """Base class for resource fetching errors."""
-
-
-class BadRequest(Error):
-    """Raised when a 400 Bad Request occurs."""
-
-
-class Unauthorized(Error):
-    """Raised when a 401 Unauthorized occurs."""
-
-
-class Forbidden(Error):
-    """Raised when a 403 Forbidden occurs."""
-
-
-class NotFound(Error):
-    """Raised when a 404 Not Found occurs."""
-
-
-class Conflict(Error):
-    """Raised when a 409 Conflict occurs."""
-
-
-class Connection:
+class ResourceManager(rackit.ResourceManager):
     """
-    Class for a connection to AWX.
+    Default resource manager for all AWX resources.
     """
-    resource_classes = {}
+    def extract_list(self, response):
+        json = response.json()
+        return json['results'], json.get('next')
+
+
+class Resource(rackit.Resource):
+    """
+    Base resource for all AWX resouces.
+    """
+    class Meta:
+        manager_cls = ResourceManager
+
+
+class Organisation(Resource):
+    class Meta:
+        endpoint = "/organizations/"
+
+
+class CredentialType(Resource):
+    class Meta:
+        endpoint = "/credential_types/"
+
+
+class Credential(Resource):
+    class Meta:
+        endpoint = "/credentials/"
+
+
+class Role(Resource):
+    class Meta:
+        endpoint = "/roles/"
+
+
+class Team(Resource):
+    class Meta:
+        endpoint = "/teams/"
+
+    roles = rackit.NestedResource(Role)
+
+
+class JobTemplate(Resource):
+    class Meta:
+        endpoint = "/job_templates/"
+        cache_keys = ('name', )
+
+    def launch(self, *args, **kwargs):
+        return self._action('launch', *args, **kwargs)
+
+
+class JobEvent(Resource):
+    class Meta:
+        endpoint = "/job_events/"
+
+
+class Job(Resource):
+    class Meta:
+        endpoint = "/jobs/"
+
+    job_events = rackit.NestedResource(JobEvent)
+
+
+class InventoryManager(ResourceManager):
+    def copy(self, resource_or_key, name):
+        endpoint = self.prepare_url(resource_or_key, 'copy')
+        response = self.connection.api_post(endpoint, json = dict(name = name))
+        return self.make_instance(self.extract_one(response))
+
+
+class InventoryVariableData(rackit.UnmanagedResource):
+    class Meta:
+        endpoint = "/variable_data/"
+
+
+class Inventory(Resource):
+    class Meta:
+        manager_cls = InventoryManager
+        endpoint = "/inventories/"
+
+    variable_data = rackit.NestedEndpoint(InventoryVariableData)
+
+    def copy(self, name):
+        return self._manager.copy(self, name)
+
+
+class Connection(rackit.Connection):
+    """
+    Class for a connection to an AWX API server.
+    """
+    path_prefix = "/api/v2"
+
+    organisations = rackit.RootResource(Organisation)
+    credential_types = rackit.RootResource(CredentialType)
+    credentials = rackit.RootResource(Credential)
+    teams = rackit.RootResource(Team)
+    job_templates = rackit.RootResource(JobTemplate)
+    jobs = rackit.RootResource(Job)
+    inventories = rackit.RootResource(Inventory)
+    roles = rackit.RootResource(Role)
+    job_events = rackit.RootResource(JobEvent)
 
     def __init__(self, url, username, password, verify_ssl = True):
-        self.session = requests.Session()
-        self.session.verify = verify_ssl
-        self.session.auth = requests.auth.HTTPBasicAuth(username, password)
-        self.api_base = url
-        self.resources = {}
-
-    def api_request(self, method, path, *args, as_json = True, **kwargs):
-        logger.info("AWX API request: {} {}".format(method.upper(), self.api_base + path))
-        response = getattr(self.session, method.lower())(
-            self.api_base + path,
-            *args,
-            **kwargs
-        )
-        try:
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as exc:
-            if exc.response.status_code == 400:
-                raise BadRequest
-            elif exc.response.status_code == 401:
-                raise Unauthorized
-            elif exc.response.status_code == 403:
-                raise Forbidden
-            elif exc.response.status_code == 404:
-                raise NotFound
-            elif exc.response.status_code == 409:
-                raise Conflict
-            else:
-                raise
-        if as_json:
-            return response.json()
-        else:
-            return response.text
-
-    def api_get(self, *args, **kwargs):
-        return self.api_request('get', *args, **kwargs)
-
-    def api_post(self, *args, **kwargs):
-        return self.api_request('post', *args, **kwargs)
-
-    def api_put(self, *args, **kwargs):
-        return self.api_request('put', *args, **kwargs)
-
-    def api_patch(self, *args, **kwargs):
-        return self.api_request('patch', *args, **kwargs)
-
-    def api_delete(self, *args, **kwargs):
-        return self.api_request('delete', *args, **kwargs)
-
-    def __getattr__(self, name):
-        # Cache the resource instance for the future
-        if name not in self.resources:
-            self.resources[name] = self.resource_classes[name](self)
-        return self.resources[name]
-
-    def close(self):
-        self.session.close()
-
-    @classmethod
-    def register_resource(cls, resource_class):
-        """
-        Decorator that registers a resource class.
-        """
-        cls.resource_classes[resource_class.name] = resource_class
-
-
-class Entity(dict):
-    """
-    Base class for an entity returned from the API.
-    """
-    def __init__(self, connection, data):
-        self._connection = connection
-        self._related_cache = {}
-        super().__init__(data)
-
-    def related_cache_has(self, related):
-        return related in self._related_cache
-
-    def related_cache_get(self, related):
-        return self._related_cache[related]
-
-    def related_cache_set(self, related, value):
-        self._related_cache[related] = value
-        return value
-
-    def related_cache_evict(self, related):
-        return self._related_cache.pop(related, None)
-
-    def __getattr__(self, name):
-        try:
-            return self[name]
-        except KeyError:
-            raise AttributeError("No such attribute '{}'".format(name))
-
-    def fetch_related(self, related, **params):
-        # Use/populate the cache as required
-        if not self.related_cache_has(related):
-            data = self._connection.api_get(self.related[related], params = params)
-            if 'results' in data:
-                return self.related_cache_set(
-                    related,
-                    tuple(Entity(self._connection, r) for r in data['results'])
-                )
-            else:
-                return self.related_cache_set(
-                    related,
-                    Entity(self._connection, data)
-                )
-        return self.related_cache_get(related)
-
-    def create_related(self, related, **params):
-        return self.related_cache_set(
-            related,
-            Entity(
-                self._connection,
-                self._connection.api_post(self.related[related], json = params)
-            )
-        )
-
-    def update_related(self, related, **params):
-        return self.related_cache_set(
-            related,
-            Entity(
-                self._connection,
-                self._connection.api_patch(self.related[related], json = params)
-            )
-        )
-
-    def cast_as(self, entity_class):
-        return entity_class(self._connection, dict(self))
-
-
-class Resource:
-    """
-    Base class for a resource.
-    """
-    #: The API endpoint for the resource
-    endpoint = None
-    #: The name of the resource
-    name = None
-    #: The plural name of the resource
-    name_plural = None
-    #: The entity class to use
-    entity_class = Entity
-
-    def __init__(self, connection):
-        self._connection = connection
-        self._cache = {}
-
-    def cache_has(self, id):
-        return str(id) in self._cache
-
-    def cache_get(self, id):
-        return self._cache[str(id)]
-
-    def cache_set(self, id, value):
-        self._cache[str(id)] = value
-        return value
-
-    def cache_evict(self, id):
-        return self._cache.pop(str(id), None)
-
-    def fetch_all(self, **params):
-        data = self._connection.api_get(self.endpoint, params = params)
-        # Cache the entities as we iterate
-        return tuple(
-            self.cache_set(r['id'], self.entity_class(self._connection, r))
-            for r in data['results']
-        )
-
-    def fetch_one(self, id = None, **params):
-        if id is not None:
-            # If doing a fetch by id, use/populate the cache
-            if not self.cache_has(id):
-                return self.cache_set(
-                    id,
-                    self.entity_class(
-                        self._connection,
-                        self._connection.api_get('{}{}/'.format(self.endpoint, id))
-                    )
-                )
-            return self.cache_get(id)
-        else:
-            try:
-                return next(iter(self.fetch_all(**params)))
-            except StopIteration:
-                raise NotFound
-
-    def create(self, **params):
-        data = self._connection.api_post(self.endpoint, json = params)
-        return self.cache_set(data['id'], self.entity_class(self._connection, data))
-
-    def delete(self, entity):
-        if isinstance(entity, Entity):
-            entity = entity.id
-        self._connection.api_delete('{}{}/'.format(self.endpoint, entity), as_json = False)
-        self.cache_evict(entity)
-
-    @classmethod
-    def make(cls, name,
-                  name_plural = None,
-                  endpoint = None,
-                  entity_class = Entity):
-        """
-        Utility function to create a new resource class where no additional
-        methods are required.
-        """
-        name_plural = name_plural or name + 's'
-        endpoint = endpoint or '/api/v2/{}/'.format(name_plural)
-        return type(
-            'Resource_{}'.format(name),
-            (cls, ),
-            dict(
-                endpoint = endpoint,
-                name = name,
-                name_plural = name_plural,
-                entity_class = entity_class
-            )
-        )
-
-
-Connection.register_resource(Resource.make('organisation', endpoint = '/api/v2/organizations/'))
-Connection.register_resource(Resource.make('credential_type'))
-Connection.register_resource(Resource.make('credential'))
-Connection.register_resource(Resource.make('team'))
-Connection.register_resource(Resource.make('job_template'))
-Connection.register_resource(Resource.make('job'))
-
-
-@Connection.register_resource
-class InventoryResource(Resource.make('inventory', 'inventories')):
-    """
-    Custom resource for inventories.
-    """
-    def copy(self, id, name):
-        inventory = self._connection.api_post(
-            '{}{}/copy/'.format(self.endpoint, id),
-            json = dict(name = name)
-        )
-        return self.cache_set(
-            inventory['id'],
-            self.entity_class(self._connection, inventory)
-        )
+        # Build the session to use basic auth for requests
+        session = requests.Session()
+        session.auth = requests.auth.HTTPBasicAuth(username, password)
+        session.verify = verify_ssl
+        super().__init__(url, session)

--- a/jasmin_cloud/provider/openstack/__init__.py
+++ b/jasmin_cloud/provider/openstack/__init__.py
@@ -1,0 +1,1 @@
+from .provider import Provider

--- a/jasmin_cloud/provider/openstack/api/__init__.py
+++ b/jasmin_cloud/provider/openstack/api/__init__.py
@@ -1,0 +1,3 @@
+from .core import Connection, AuthParams
+# Import the modules for each of the services
+from . import block_store, compute, image, network, orchestration

--- a/jasmin_cloud/provider/openstack/api/block_store.py
+++ b/jasmin_cloud/provider/openstack/api/block_store.py
@@ -1,0 +1,53 @@
+"""
+Module containing service and resource definitions for the OpenStack compute API.
+"""
+
+from rackit import RootResource, EmbeddedResource, Endpoint
+
+from .core import Service, ResourceWithDetail, UnmanagedResource
+from .image import Image
+
+
+class AbsoluteLimits(UnmanagedResource):
+    """
+    Represents the absolute limits for a project.
+    """
+    class Meta:
+        aliases = dict(
+            total_volume_gigabytes = 'maxTotalVolumeGigabytes',
+            total_gigabytes_used = 'totalGigabytesUsed',
+            volumes = 'maxTotalVolumes',
+            volumes_used = 'totalVolumesUsed'
+        )
+
+
+class Limits(UnmanagedResource):
+    """
+    Represents the limits for a project.
+
+    This is not a REST-ful resource, so is unmanaged.
+    """
+    class Meta:
+        endpoint = "/limits"
+
+    absolute = EmbeddedResource(AbsoluteLimits)
+
+
+class Volume(ResourceWithDetail):
+    """
+    Resource for accessing flavors.
+    """
+    class Meta:
+        endpoint = '/volumes'
+
+
+class BlockStoreService(Service):
+    """
+    OpenStack service class for the block store service.
+    """
+    name = 'block_store'
+    catalog_type = 'volumev3'
+    path_prefix = '/v3/{project_id}'
+
+    limits = Endpoint(Limits)
+    volumes = RootResource(Volume)

--- a/jasmin_cloud/provider/openstack/api/compute.py
+++ b/jasmin_cloud/provider/openstack/api/compute.py
@@ -1,0 +1,121 @@
+"""
+Module containing service and resource definitions for the OpenStack compute API.
+"""
+
+from rackit import RootResource, NestedResource, EmbeddedResource, Endpoint
+
+from .core import (
+    Service,
+    UnmanagedResource,
+    ResourceManager,
+    Resource,
+    ResourceWithDetailManager,
+    ResourceWithDetail
+)
+from .image import Image
+
+
+class Flavor(ResourceWithDetail):
+    """
+    Resource for accessing flavors.
+    """
+    class Meta:
+        endpoint = '/flavors'
+        aliases = dict(
+            is_disabled = 'OS-FLV-DISABLED:disabled'
+        )
+
+
+class Keypair(Resource):
+    """
+    Resource for a keypair.
+    """
+    class Meta:
+        endpoint = '/os-keypairs'
+        resource_list_key = 'keypairs'
+        primary_key_field = 'name'
+
+
+class VolumeAttachment(Resource):
+    """
+    Resource for a nested resource.
+    """
+    class Meta:
+        endpoint = "/os-volume_attachments"
+        resource_list_key = "volumeAttachments"
+        resource_key = "volumeAttachment"
+        aliases = dict(
+            server_id = 'serverId',
+            volume_id = 'volumeId'
+        )
+
+
+class Server(ResourceWithDetail):
+    """
+    Resource for a server.
+    """
+    class Meta:
+        endpoint = '/servers'
+        aliases = dict(
+            image_id = 'imageRef',
+            flavor_id = 'flavorRef',
+            task_state = 'OS-EXT-STS:task_state',
+            power_state = 'OS-EXT-STS:power_state',
+            attached_volumes = 'os-extended-volumes:volumes_attached'
+        )
+        defaults = dict(
+            fault = dict
+        )
+
+    flavor = EmbeddedResource(Flavor)
+    image = EmbeddedResource(Image)
+    volume_attachments = NestedResource(VolumeAttachment)
+
+    def start(self):
+        self._action('action', { 'os-start': None })
+
+    def stop(self):
+        self._action('action', { 'os-stop': None })
+
+    def reboot(self, reboot_type):
+        self._action('action', { 'reboot': { 'type': reboot_type } })
+
+
+class AbsoluteLimits(UnmanagedResource):
+    """
+    Represents the absolute limits for a project.
+    """
+    class Meta:
+        aliases = dict(
+            total_cores = 'maxTotalCores',
+            total_cores_used = 'totalCoresUsed',
+            total_ram = 'maxTotalRAMSize',
+            total_ram_used = 'totalRAMUsed',
+            instances = 'maxTotalInstances',
+            instances_used = 'totalInstancesUsed'
+        )
+
+
+class Limits(UnmanagedResource):
+    """
+    Represents the limits for a project.
+
+    This is not a REST-ful resource, so is unmanaged.
+    """
+    class Meta:
+        endpoint = "/limits"
+
+    absolute = EmbeddedResource(AbsoluteLimits)
+
+
+class ComputeService(Service):
+    """
+    OpenStack service class for the compute service.
+    """
+    catalog_type = 'compute'
+    path_prefix = '/v2.1'
+
+    flavors = RootResource(Flavor)
+    keypairs = RootResource(Keypair)
+    servers = RootResource(Server)
+    limits = Endpoint(Limits)

--- a/jasmin_cloud/provider/openstack/api/core.py
+++ b/jasmin_cloud/provider/openstack/api/core.py
@@ -1,0 +1,372 @@
+"""
+Module containing helpers for interacting with the OpenStack API.
+"""
+
+import collections
+import logging
+import re
+from urllib.parse import urlsplit
+import json
+
+import requests
+
+import rackit
+
+
+logger = logging.getLogger(__name__)
+
+
+class AuthParams:
+    """
+    Builder object for setting authentication parameters.
+    """
+    def __init__(self, params = None):
+        self.params = params or dict()
+
+    def use_token(self, token):
+        """
+        Returns an auth object using the given token for authentication.
+        """
+        params = self.params.copy()
+        params.update(identity = dict(methods = ['token'], token = dict(id = token)))
+        return self.__class__(params)
+
+    def use_password(self, domain, username, password):
+        """
+        Returns an auth object using the given domain, username and password
+        for authentication.
+        """
+        params = self.params.copy()
+        params.update(
+            identity = dict(
+                methods = ['password'],
+                password = dict(
+                    user = dict(
+                        domain = dict(name = domain),
+                        name = username,
+                        password = password
+                    )
+                )
+            )
+        )
+        return self.__class__(params)
+
+    def use_project_id(self, project_id):
+        """
+        Returns an auth object scoped to the given project.
+        """
+        params = self.params.copy()
+        params.update(scope = dict(project = dict(id = project_id)))
+        return self.__class__(params)
+
+    def as_dict(self):
+        """
+        Returns the auth parameters as a dict.
+        """
+        return self.params.copy()
+
+
+class UnmanagedResourceOptions(rackit.resource.Options):
+    def __init__(self, options = None):
+        options = options or dict()
+        endpoint = options.get('endpoint')
+        if endpoint:
+            if 'resource_key' not in options:
+                options.update(
+                    resource_key = endpoint.strip('/')
+                )
+        super().__init__(options)
+
+
+class UnmanagedResource(rackit.UnmanagedResource):
+    """
+    Base class for unmanaged OpenStack resources.
+    """
+    class Meta:
+        options_cls = UnmanagedResourceOptions
+
+    def _fetch(self, path = None):
+        # The data is under a key, which we need to extract
+        return super()._fetch(path)[self._opts.resource_key]
+
+
+class ResourceManager(rackit.ResourceManager):
+    """
+    Base class for an OpenStack resource manager.
+    """
+    def related_manager(self, resource_cls):
+        # Modify related manager discovery to handle cross-service relationships
+        resource_cls = self.related_resource(resource_cls)
+        # Get the catalog type of the related resource
+        catalog_type = resource_cls._connection_cls.catalog_type
+        # Use the main connection to get the service for the resource
+        service_name = catalog_type.replace('-', '_')
+        service = getattr(self.connection.session.auth, service_name)
+        # Then return the root manager for the resource class in that service
+        root = service.root_manager(resource_cls)
+        if root:
+            return root
+        else:
+            raise RuntimeError('Unable to locate manager for embedded resource')
+
+    def extract_list(self, response):
+        # OpenStack responses have the list under a named key
+        # If there is a next page, that is provided under a links attribute
+        json = response.json()
+        data = json[self.resource_cls._opts.resource_list_key]
+        next_url = next(
+            (
+                link['href']
+                for link in json.get(self.resource_cls._opts.resource_links_key, [])
+                if link['rel'] == 'next'
+            ),
+            None
+        )
+        return data, next_url
+
+    def extract_one(self, response):
+        # Some OpenStack responses have the instance under a named key
+        if self.resource_cls._opts.resource_key:
+            return response.json()[self.resource_cls._opts.resource_key]
+        else:
+            return response.json()
+
+    def prepare_params(self, params):
+        # If there is a resource key, nest the parameters using it
+        params = super().prepare_params(params)
+        if self.resource_cls._opts.resource_key:
+            return { self.resource_cls._opts.resource_key: params }
+        else:
+            return params
+
+
+class ResourceWithDetailManager(ResourceManager):
+    """
+    Base class for a resource where lists can be fetched with or without detail.
+
+    When a list is fetched without detail, partial entities will be returned.
+    """
+    def all(self, detail = True, **params):
+        endpoint = self.prepare_url()
+        if detail:
+            endpoint = endpoint + '/detail'
+        return self._fetch_all(endpoint, params, not detail)
+
+
+class ResourceOptions(rackit.resource.Options):
+    """
+    Custom options class derives default options for OpenStack resources.
+    """
+    def __init__(self, options = None):
+        options = options or dict()
+        endpoint = options.get('endpoint')
+        if endpoint:
+            # Derive default values for response keys, if not given
+            if 'resource_list_key' not in options:
+                options.update(
+                    resource_list_key = endpoint.strip('/')
+                )
+            if 'resource_links_key' not in options:
+                options.update(
+                    resource_links_key = '{}_links'.format(options['resource_list_key'])
+                )
+            if 'resource_key' not in options:
+                options.update(
+                    # By default, assume the list key ends with an 's' that we trim
+                    resource_key = options['resource_list_key'][:-1]
+                )
+        super().__init__(options)
+
+
+class Resource(rackit.Resource):
+    """
+    Base class for OpenStack resources.
+    """
+    class Meta:
+        options_cls = ResourceOptions
+        manager_cls = ResourceManager
+        update_http_verb = 'put'
+
+
+class ResourceWithDetail(Resource):
+    """
+    Base class for OpenStack resources that support a detail view.
+    """
+    class Meta:
+        manager_cls = ResourceWithDetailManager
+
+
+class AuthProject(Resource):
+    """
+    Resource for the projects for a user.
+
+    Manipulation of projects more generally is available through the identity service.
+    """
+    class Meta:
+        endpoint = '/auth/projects'
+        resource_list_key = 'projects'
+
+
+class Connection(rackit.Connection):
+    """
+    Class for a connection to an OpenStack API, which handles the authentication,
+    project and service discovery elements.
+
+    Can be used as an auth object for a requests session.
+    """
+    projects = rackit.RootResource(AuthProject)
+
+    def __init__(self, auth_url, params, interface = 'public', verify = True):
+        # Store the given parameters, as it is sometimes useful to be able to query them later
+        self.auth_url = auth_url.rstrip('/')
+        self.params = params
+        self.interface = interface
+        self.verify = verify
+
+        # Configure the session
+        session = requests.Session()
+        # This object is the auth object for the session
+        session.auth = self
+        session.verify = verify
+
+        # Once the superclass init is called, we can use the api_{} methods
+        super().__init__(auth_url, session)
+
+        # Attempt the authentication
+        try:
+            response = self.api_post('/auth/tokens', json = dict(auth = params.as_dict()))
+        except rackit.ApiError:
+            # If the authentication fails, make sure we close the session
+            session.close()
+            raise
+        # Extract the token from the headers
+        self.token = response.headers['X-Subject-Token']
+        # Extract information from the response
+        json = response.json()
+        self.username = json['token']['user']['name']
+        self.project_id = json['token'].get('project', {}).get('id')
+        # Extract the endpoints from the catalog on the correct interface
+        self.endpoints = {}
+        for entry in json['token'].get('catalog', []):
+            # Find the endpoint on the specified interface
+            try:
+                endpoint = next(
+                    ep['url']
+                    for ep in entry['endpoints']
+                    if ep['interface'] == self.interface
+                )
+            except StopIteration:
+                continue
+            # Strip any path component from the endpoint
+            self.endpoints[entry['type']] = urlsplit(endpoint)._replace(path = '').geturl()
+
+    def __call__(self, request):
+        # This is what allows the connection to be used as a requests auth
+        # If there is a token, set the OpenStack auth token header
+        try:
+            request.headers['X-Auth-Token'] = self.token
+        except AttributeError:
+            pass
+        return request
+
+    def scoped_connection(self, project_or_id):
+        """
+        Return a new connection that is scoped to the given project.
+        """
+        # Extract the project id from a resource if required
+        if isinstance(project_or_id, Resource):
+            project_id = project_or_id.id
+        else:
+            project_id = project_or_id
+        return Connection(
+            self.auth_url,
+            # Use token authentication with our token
+            AuthParams().use_token(self.token).use_project_id(project_id),
+            self.interface,
+            self.verify
+        )
+
+
+class ServiceDescriptor(rackit.CachedProperty):
+    """
+    Property descriptor for attaching a :py:class:`Service` to a :py:class:`Connection`.
+
+    The returned service instances are configured using the endpoints discovered from
+    the service catalog.
+    """
+    def __init__(self, service_cls):
+        self.service_cls = service_cls
+        super().__init__(self.get_service)
+
+    def get_service(self, instance):
+        url = instance.endpoints[self.service_cls.catalog_type]
+        return self.service_cls(url, instance.session)
+
+
+class Service(rackit.Connection):
+    """
+    Base class for OpenStack service connections.
+    """
+    #: The name of the catalog type that this service is for
+    #: This is used to retrieve the endpoint from the service catalog
+    catalog_type = None
+    #: The path prefix for this service, e.g. a specific version
+    #: The path part is stripped from the endpoint in the service catalog
+    #: and replaced with this
+    #: The project id is interpolated into the prefix using ``str.format(project_id = ...)``.
+    path_prefix = None
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        # If the service has a catalog type, add it to the connection
+        if cls.catalog_type:
+            # If no explicit name is given, use the catalog type
+            name = getattr(cls, 'name', cls.catalog_type.replace('-', '_'))
+            descriptor = ServiceDescriptor(cls)
+            setattr(Connection, name, descriptor)
+            descriptor.__set_name__(Connection, name)
+
+    def __init__(self, url, session):
+        super().__init__(url, session)
+        # Resolve the path prefix for this instance by templating in the project id
+        if self.path_prefix:
+            # Template the project id into the path prefix
+            project_id = session.auth.project_id
+            self.path_prefix = self.path_prefix.format(project_id = project_id)
+
+    def prepare_url(self, url):
+        # If the URL is absolute, then use it as-is
+        if re.match('https?://', url) is not None:
+            return url
+        # Treat the url as a path now
+        # If it doesn't already start with the path prefix, prepend it
+        if self.path_prefix and not url.startswith(self.path_prefix):
+            url = self.path_prefix + url
+        # Prepend the API base URL
+        return self.api_base + url
+
+    def _find_message(self, obj):
+        # Try to find a message property at any depth within the structure
+        if isinstance(obj, dict):
+            try:
+                return obj['message']
+            except KeyError:
+                for item in obj.values():
+                    message = self._find_message(item)
+                    if message:
+                        return message
+
+    def extract_error_message(self, response):
+        """
+        Extract an error message from the given error response and return it.
+        """
+        # First, try to parse the response as JSON
+        # If it fails, just use the response text
+        try:
+            json_obj = response.json()
+        except json.decoder.JSONDecodeError:
+            return response.text
+        else:
+            # Traverse the structure looking for a message property
+            # Use the response text if not found
+            return self._find_message(json_obj) or response.text

--- a/jasmin_cloud/provider/openstack/api/image.py
+++ b/jasmin_cloud/provider/openstack/api/image.py
@@ -1,0 +1,27 @@
+"""
+Module containing service and resource definitions for the OpenStack image API.
+"""
+
+from rackit import RootResource
+
+from .core import Service, Resource
+
+
+class Image(Resource):
+    """
+    Resource for accessing images.
+    """
+    class Meta:
+        endpoint = '/images'
+        # The image service returns the image data directly when fetching by id
+        resource_key = None
+
+
+class ImageService(Service):
+    """
+    OpenStack service class for the image service.
+    """
+    catalog_type = 'image'
+    path_prefix = '/v2'
+
+    images = RootResource(Image)

--- a/jasmin_cloud/provider/openstack/api/network.py
+++ b/jasmin_cloud/provider/openstack/api/network.py
@@ -1,0 +1,74 @@
+"""
+Module containing service and resource definitions for the OpenStack compute API.
+"""
+
+from rackit import Endpoint, RootResource
+
+from .core import Service, UnmanagedResource, Resource
+
+
+class Quotas(UnmanagedResource):
+    """
+    Represents the quotas for a project.
+
+    This is not a REST-ful resource, so is unmanaged.
+    """
+    class Meta:
+        endpoint = "/quotas/{project_id}"
+        resource_key = "quota"
+
+    def _fetch(self, path = None):
+        # Interpolate the project id into the endpoint before fetching
+        if not path:
+            # Interpolate the project id from the auth object into the endpoint
+            path = self._opts.endpoint.format(
+                project_id = self._connection.session.auth.project_id
+            )
+        return super()._fetch(path)
+
+
+class FloatingIp(Resource):
+    """
+    Represents a floating IP.
+    """
+    class Meta:
+        endpoint = "/floatingips"
+
+
+class Port(Resource):
+    """
+    Represents a port.
+    """
+    class Meta:
+        endpoint = "/ports"
+
+
+class Network(Resource):
+    """
+    Represents a network.
+    """
+    class Meta:
+        endpoint = "/networks"
+
+
+class Router(Resource):
+    """
+    Represents a router.
+    """
+    class Meta:
+        endpoint = "/routers"
+
+
+class NetworkService(Service):
+    """
+    OpenStack service class for the network service.
+    """
+    catalog_type = 'network'
+    path_prefix = '/v2.0'
+    error_keys = ('NeutronError', 'message')
+
+    quotas = Endpoint(Quotas)
+    floatingips = RootResource(FloatingIp)
+    ports = RootResource(Port)
+    networks = RootResource(Network)
+    routers = RootResource(Router)

--- a/jasmin_cloud/provider/openstack/api/network.py
+++ b/jasmin_cloud/provider/openstack/api/network.py
@@ -17,14 +17,12 @@ class Quotas(UnmanagedResource):
         endpoint = "/quotas/{project_id}"
         resource_key = "quota"
 
-    def _fetch(self, path = None):
-        # Interpolate the project id into the endpoint before fetching
-        if not path:
-            # Interpolate the project id from the auth object into the endpoint
-            path = self._opts.endpoint.format(
-                project_id = self._connection.session.auth.project_id
-            )
-        return super()._fetch(path)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Interpolate the project id into the path
+        self._path = self._path.format(
+            project_id = self._connection.session.auth.project_id
+        )
 
 
 class FloatingIp(Resource):

--- a/jasmin_cloud/provider/openstack/api/orchestration.py
+++ b/jasmin_cloud/provider/openstack/api/orchestration.py
@@ -1,0 +1,25 @@
+"""
+Module containing service and resource definitions for the OpenStack image API.
+"""
+
+from rackit import RootResource
+
+from .core import Service, Resource
+
+
+class Stack(Resource):
+    """
+    Resource for accessing stacks.
+    """
+    class Meta:
+        endpoint = '/stacks'
+
+
+class OrchestrationService(Service):
+    """
+    OpenStack service class for the orchestration service.
+    """
+    catalog_type = 'orchestration'
+    path_prefix = '/v1/{project_id}'
+
+    stacks = RootResource(Stack)

--- a/jasmin_cloud/provider/openstack/provider.py
+++ b/jasmin_cloud/provider/openstack/provider.py
@@ -6,41 +6,47 @@ import functools
 import logging
 import base64
 import hashlib
+import json
 
 import dateutil.parser
-from openstack import connection, config, exceptions, resource
-from openstack.image.v2.image import Image as BaseImage
-from openstack.compute.v2 import server
-from keystoneauth1 import exceptions as keystone_exceptions
 
-from . import base, errors, dto
-from jasmin_cloud_site import __version__
+import rackit
+
+from . import api
+from .. import base, errors, dto
 
 
 logger = logging.getLogger(__name__)
 
 
-def convert_sdk_exceptions(f):
+_REPLACEMENTS = [
+    ('instance', 'machine'),
+    ('Instance', 'Machine'),
+    ('flavorRef', 'size'),
+    ('flavor', 'size'),
+    ('Flavor', 'Size')
+]
+def _replace_resource_names(message):
+    return functools.reduce(
+        lambda a, x: a.replace(x[0], x[1]),
+        _REPLACEMENTS,
+        message
+    )
+
+
+def convert_exceptions(f):
     """
-    Decorator that converts OpenStack SDK exceptions into errors from :py:mod:`.errors`.
+    Decorator that converts OpenStack API exceptions into errors from :py:mod:`..errors`.
     """
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
         try:
             return f(*args, **kwargs)
-        except exceptions.ResourceNotFound as e:
-            message = _replace_resource_names(e.details.replace('404 Not Found: ', ''))
-            raise errors.ObjectNotFoundError(message)
-        except (exceptions.HttpException, keystone_exceptions.http.HttpError) as e:
-            # Status code is in one of two attributes
-            if hasattr(e, 'status_code'):
-                # This is an SDK exception
-                status_code = e.status_code
-                message = _replace_resource_names(e.details)
-            else:
-                # This is a raw session exception
-                status_code = e.http_status
-                message = e.message
+        except rackit.ApiError as exc:
+            # Extract the status code and message
+            status_code = exc.status_code
+            # Replace the OpenStack resource names with ours
+            message = _replace_resource_names(str(exc))
             if status_code == 400:
                 raise errors.BadInputError(message)
             elif status_code == 401:
@@ -65,35 +71,20 @@ def convert_sdk_exceptions(f):
                         'Please check your tenancy quotas.'
                     )
                 raise errors.InvalidOperationError(message)
+            elif status_code == 413:
+                # The volume service uses 413 (Payload too large) for quota errors
+                if 'exceedsavailablequota' in message.lower():
+                    raise errors.QuotaExceededError(
+                        'Requested operation would exceed at least one quota. '
+                        'Please check your tenancy quotas.'
+                    )
+                raise errors.CommunicationError('Unknown error with OpenStack API.')
             else:
-                raise errors.CommunicationError('Error communicating with OpenStack API.')
-        except (exceptions.SDKException, keystone_exceptions.base.ClientException) as e:
-            logger.exception('Unknown error in OpenStack SDK')
-            raise errors.Error('Unknown error in OpenStack SDK.')
+                raise errors.CommunicationError('Unknown error with OpenStack API.')
+        except rackit.RackitError as exc:
+            logger.exception('Could not connect to OpenStack API.')
+            raise errors.CommunicationError('Could not connect to OpenStack API.')
     return wrapper
-
-
-def getattr_nested(obj, path, default):
-    if len(path) > 1:
-        part = path[0]
-        if hasattr(obj, part):
-            return getattr_nested(getattr(obj, part), path[1:], default)
-        else:
-            return default
-    else:
-        return getattr(obj, path[0], default)
-
-
-def close_openstack_connection(connection):
-    """
-    Closes the given ``openstacksdk.connection.Connection`` in a way that doesn't leave
-    dangling connections in the ``CLOSE_WAIT`` state.
-    """
-    # Close the connection itself
-    connection.close()
-    # Also close the underlying requests session, if one exists
-    # This seems to prevent the dangling connections
-    getattr_nested(connection, ('session', 'session', 'close'), lambda: None)()
 
 
 class Provider(base.Provider):
@@ -129,82 +120,44 @@ class Provider(base.Provider):
         self._verify_ssl = verify_ssl
         self._cluster_engine = cluster_engine
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def authenticate(self, username, password):
         """
         See :py:meth:`.base.Provider.authenticate`.
         """
         logger.info('Authenticating user %s with OpenStack', username)
-        # Create an SDK connection using the username and password
-        conn = connection.Connection(
-            auth_type = 'password',
-            auth = dict(
-                auth_url = self._auth_url,
-                username = username,
-                password = password,
-                user_domain_name = self._domain
-            ),
-            interface = self._interface,
-            verify = self._verify_ssl
-        )
-        # Force the connection to validate the credentials
+        # Create an API connection using the username and password
+        auth_params = api.AuthParams().use_password(self._domain, username, password)
         try:
-            _ = conn.authorize()
-        except exceptions.HttpException as e:
-            close_openstack_connection(conn)
-            if e.status_code == 401:
-                raise errors.AuthenticationError('Invalid username or password.')
-            raise
-        return UnscopedSession(
-            conn,
-            secondary_network_id = self._secondary_network_id,
-            cluster_engine = self._cluster_engine
-        )
+            conn = api.Connection(self._auth_url, auth_params, self._interface, self._verify_ssl)
+        except rackit.Unauthorized:
+            # We want to use a different error message to convert_exceptions
+            raise errors.AuthenticationError('Invalid username or password.')
+        else:
+            return UnscopedSession(
+                conn,
+                secondary_network_id = self._secondary_network_id,
+                cluster_engine = self._cluster_engine
+            )
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def from_token(self, token):
         """
         See :py:meth:`.base.Provider.from_token`.
         """
         logger.info('Authenticating token with OpenStack')
-        conn = connection.Connection(
-            auth_type = 'token',
-            auth = dict(
-                auth_url = self._auth_url,
-                token = token
-            ),
-            interface = self._interface,
-            verify = self._verify_ssl
-        )
-        # Force the connection to validate the token
+        auth_params = api.AuthParams().use_token(token)
         try:
-            _ = conn.authorize()
-        except exceptions.HttpException as e:
-            close_openstack_connection(conn)
+            conn = api.Connection(self._auth_url, auth_params, self._interface, self._verify_ssl)
+        except (rackit.Unauthorized, rackit.NotFound):
             # Failing to validate a token is a 404 for some reason
-            if e.status_code in {401, 404}:
-                raise errors.AuthenticationError('Your session has expired.')
-            raise
-        return UnscopedSession(
-            conn,
-            secondary_network_id = self._secondary_network_id,
-            cluster_engine = self._cluster_engine
-        )
-
-
-_REPLACEMENTS = [
-    ('instance', 'machine'),
-    ('Instance', 'Machine'),
-    ('flavorRef', 'size'),
-    ('flavor', 'size'),
-    ('Flavor', 'Size')
-]
-def _replace_resource_names(message):
-    return functools.reduce(
-        lambda a, x: a.replace(x[0], x[1]),
-        _REPLACEMENTS,
-        message
-    )
+            raise errors.AuthenticationError('Your session has expired.')
+        else:
+            return UnscopedSession(
+                conn,
+                secondary_network_id = self._secondary_network_id,
+                cluster_engine = self._cluster_engine
+            )
 
 
 class UnscopedSession(base.UnscopedSession):
@@ -212,7 +165,7 @@ class UnscopedSession(base.UnscopedSession):
     Unscoped session implementation for OpenStack.
 
     Args:
-        connection: An unscoped ``openstack.connection.Connection``.
+        connection: An unscoped :py:mod:`.api.Connection`.
         secondary_network_id: The UUID of a second network to connect to new machines
                               when available. OPTIONAL, default ``None``.
                               If the network is not given or not available to a
@@ -222,109 +175,67 @@ class UnscopedSession(base.UnscopedSession):
     """
     provider_name = 'openstack'
 
-    def __init__(self, connection,
-                       secondary_network_id = None,
-                       cluster_engine = None):
+    def __init__(self, connection, secondary_network_id = None, cluster_engine = None):
         self._connection = connection
         self._secondary_network_id = secondary_network_id
         self._cluster_engine = cluster_engine
-        # Either pull an existing token out of the connection or create a new one
-        token = connection.config.config['auth'].get('token')
-        if token is not None:
-            self._token = token
-        else:
-            logger.info('Fetching token from OpenStack')
-            self._token = connection.authorize()
-        # Pull a username out of the connection as well
-        # We can't do this through the SDK proxies as we get "service catalog empty" errors
-        response = connection.session.get(
-            connection.config.config['auth']['auth_url'] + '/auth/tokens',
-            headers = { 'X-Subject-Token': self._token }
-        )
-        self._username = response.json()['token']['user']['name']
 
     def token(self):
         """
         See :py:meth:`.base.UnscopedSession.token`.
         """
-        return self._token
+        return self._connection.token
 
     def username(self):
         """
         See :py:meth:`.base.UnscopedSession.username`.
         """
-        return self._username
+        return self._connection.username
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def tenancies(self):
         """
         See :py:meth:`.base.UnscopedSession.tenancies`.
         """
-        logger.info('[%s] Fetching available tenancies', self._username)
-        # Getting an unscoped token and then retrieving tenancies later seems to
-        # be impossible to do through the SDK due to "service catalog empty" errors
-        auth_url = self._connection.config.config['auth']['auth_url']
-        response = self._connection.session.get(auth_url + '/auth/projects')
-        try:
-            projects = response.json()['projects']
-            logger.info('[%s] Found %s projects', self._username, len(projects))
-            return tuple(dto.Tenancy(p['id'], p['name']) for p in projects if p['enabled'])
-        except KeyError:
-            raise errors.CommunicationError(
-                'Unable to extract tenancy information from response'
-            )
+        logger.info('[%s] Fetching available tenancies', self.username())
+        projects = tuple(self._connection.projects.all())
+        logger.info('[%s] Found %s projects', self.username(), len(projects))
+        return tuple(dto.Tenancy(p.id, p.name) for p in projects if p.enabled)
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def scoped_session(self, tenancy):
         """
         See :py:meth:`.base.UnscopedSession.scoped_session`.
         """
-        # Make sure we have a tenancy object
-        # If we were given an ID, just do this by fetching all the tenancies and
-        # searching them, rather than fetching by id. Either way it is one HTTP
-        # request, which is the time-consuming bit, and we don't have to repeat
-        # all the error handling :-P
+        # Make sure we have a tenancy id
         if not isinstance(tenancy, dto.Tenancy):
+            # There is no (obvious) way to list individual auth projects, so traverse the list
             try:
                 tenancy = next(t for t in self.tenancies() if t.id == tenancy)
             except StopIteration:
                 raise errors.ObjectNotFoundError(
                     'Could not find tenancy with ID {}'.format(tenancy)
                 )
-        logger.info('[%s] [%s] Creating scoped session', self._username, tenancy.name)
+        logger.info('[%s] [%s] Creating scoped session', self.username(), tenancy.name)
         try:
             return ScopedSession(
-                self._username,
+                self.username(),
                 tenancy,
-                connection.Connection(
-                    auth_type = 'token',
-                    auth = dict(
-                        auth_url = self._connection.config.config['auth']['auth_url'],
-                        token = self._token,
-                        project_id = tenancy.id
-                    ),
-                    interface = self._connection.config.config['interface'],
-                    verify = self._connection.config.config['verify']
-                ),
+                self._connection.scoped_connection(tenancy.id),
                 secondary_network_id = self._secondary_network_id,
                 cluster_engine = self._cluster_engine
             )
-        except exceptions.HttpException as e:
-            # If creating the session fails with an auth error, convert that to
-            # not found to avoid revealing details about valid tenancies
-            if e.status_code in { 401, 403 }:
-                raise errors.ObjectNotFoundError(
-                    'Could not find tenancy with ID {}'.format(tenancy.id)
-                )
-            else:
-                raise e
+        except (rackit.Unauthorized, rackit.Forbidden):
+            raise errors.ObjectNotFoundError(
+                'Could not find tenancy with ID {}'.format(tenancy.id)
+            )
 
     def close(self):
         """
         See :py:meth:`.base.UnscopedSession.close`.
         """
-        # Make sure the underlying requests session is closed
-        close_openstack_connection(self._connection)
+        # Just close the underlying connection
+        self._connection.close()
 
 
 class ScopedSession(base.ScopedSession):
@@ -362,7 +273,7 @@ class ScopedSession(base.ScopedSession):
             self._username, self._tenancy.name, *args, **kwargs
         )
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def quotas(self):
         """
         See :py:meth:`.base.ScopedSession.quotas`.
@@ -370,7 +281,7 @@ class ScopedSession(base.ScopedSession):
         self._log('Fetching tenancy quotas')
         # Compute provides a way to fetch this information through the SDK, but
         # the floating IP quota obtained through it is rubbish...
-        compute_limits = self._connection.compute.get_limits().absolute
+        compute_limits = self._connection.compute.limits.absolute
         quotas = [
             dto.Quota(
                 'cpus',
@@ -391,74 +302,50 @@ class ScopedSession(base.ScopedSession):
                 compute_limits.instances_used
             ),
         ]
-        interface = self._connection.config.config['interface']
-        # For block storage and floating IPs, use the API directly
-        network_ep = self._connection.network.get_endpoint(interface = interface)
-        network_quotas = self._connection.session.get(
-            network_ep + '/quotas/' + self._tenancy.id
-        ).json()
+        # Get the floating ip quota
+        network_quotas = self._connection.network.quotas
         quotas.append(
             dto.Quota(
                 'external_ips',
                 None,
-                network_quotas['quota']['floatingip'],
-                len(list(self._connection.network.ips()))
+                network_quotas.floatingip,
+                # Just get the length of the list of IPs
+                len(list(self._connection.network.floatingips.all()))
             )
         )
-        volume_ep = self._connection.volume.get_endpoint(interface = interface)
-        volume_limits = self._connection.session.get(volume_ep + '/limits').json()
+        volume_limits = self._connection.block_store.limits.absolute
         quotas.extend([
             dto.Quota(
                 'storage',
                 'GB',
-                volume_limits['limits']['absolute']['maxTotalVolumeGigabytes'],
-                volume_limits['limits']['absolute']['totalGigabytesUsed']
+                volume_limits.total_volume_gigabytes,
+                volume_limits.total_gigabytes_used
             ),
             dto.Quota(
                 'volumes',
                 None,
-                volume_limits['limits']['absolute']['maxTotalVolumes'],
-                volume_limits['limits']['absolute']['totalVolumesUsed']
+                volume_limits.volumes,
+                volume_limits.volumes_used
             )
         ])
         return quotas
 
-    class Image(BaseImage):
+    def _from_api_image(self, api_image):
         """
-        Custom image resource with custom properties defined.
-
-        The OpenStack SDK seems to make it impossible to consume custom properties
-        without doing this...
-        """
-        # Metadata indicating the type of server the image deploys
-        jasmin_type = resource.Body('jasmin_type')
-        # Flag indicating if the machine is allowed to be NATed
-        jasmin_nat_allowed = resource.Body('jasmin_nat_allowed')
-        # Flag indicating whether the image is a cluster image
-        # Cluster images are excluded from the image list
-        jasmin_cluster_image = resource.Body('jasmin_cluster_image')
-        # Metadata providing the name of the private interface
-        # If this metadata is present, the private network is connected
-        jasmin_private_if = resource.Body('jasmin_private_if')
-        # Metadata indicating the activator version to use
-        jasmin_activ_ver = resource.Body('jasmin_activ_ver')
-
-    def _from_sdk_image(self, sdk_image):
-        """
-        Converts an OpenStack SDK image object into a :py:class:`.dto.Image`.
+        Converts an OpenStack API image object into a :py:class:`.dto.Image`.
         """
         return dto.Image(
-            sdk_image.id,
-            sdk_image.jasmin_type or 'UNKNOWN',
-            sdk_image.name,
-            sdk_image.visibility == 'public',
+            api_image.id,
+            getattr(api_image, 'jasmin_type', 'UNKNOWN'),
+            api_image.name,
+            api_image.visibility == 'public',
             # Unless specifically disallowed by a flag, NAT is allowed
-            bool(int(sdk_image.jasmin_nat_allowed or '1')),
+            bool(int(getattr(api_image, 'jasmin_nat_allowed', '1'))),
             # The image size is specified in bytes. Convert to MB.
-            float(sdk_image.size) / 1024.0 / 1024.0
+            float(api_image.size) / 1024.0 / 1024.0
         )
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def images(self):
         """
         See :py:meth:`.base.ScopedSession.images`.
@@ -468,90 +355,65 @@ class ScopedSession(base.ScopedSession):
         # Exclude cluster images from the returned list
         images = list(
             image
-            for image in self._connection.image._list(self.Image, status = 'active')
-            if not int(image.jasmin_cluster_image or '0')
+            for image in self._connection.image.images.all(status = 'active')
+            if not int(getattr(image, 'jasmin_cluster_image', '0'))
         )
         self._log('Found %s images', len(images))
-        return tuple(self._from_sdk_image(i) for i in images)
+        return tuple(self._from_api_image(i) for i in images)
 
-    @convert_sdk_exceptions
-    @functools.lru_cache()
-    def _find_sdk_image(self, id):
-        """
-        Finds the raw SDK image, but with exceptions converted.
-        """
-        self._log("Fetching image with id '%s'", id)
-        # Fetch from the SDK using our custom image resource
-        return self._connection.image._get(self.Image, id)
-
+    @convert_exceptions
     def find_image(self, id):
         """
         See :py:meth:`.base.ScopedSession.find_image`.
         """
+        self._log("Fetching image with id '%s'", id)
         # Just convert the SDK image to a DTO image
-        return self._from_sdk_image(self._find_sdk_image(id))
+        return self._from_api_image(self._connection.image.images.get(id))
 
-    def _from_sdk_flavor(self, sdk_flavor):
+    def _from_api_flavor(self, api_flavor):
         """
-        Converts an OpenStack SDK flavor object into a :py:class:`.dto.Size`.
+        Converts an OpenStack API flavor object into a :py:class:`.dto.Size`.
         """
         return dto.Size(
-            sdk_flavor.id,
-            sdk_flavor.name,
-            sdk_flavor.vcpus,
-            sdk_flavor.ram,
-            sdk_flavor.disk
+            api_flavor.id,
+            api_flavor.name,
+            api_flavor.vcpus,
+            api_flavor.ram,
+            api_flavor.disk
         )
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def sizes(self):
         """
         See :py:meth:`.base.ScopedSession.sizes`.
         """
         self._log('Fetching available flavors')
-        all_flavors = self._connection.compute.flavors()
-        flavors = list(f for f in all_flavors if not f.is_disabled)
+        flavors = tuple(
+            self._from_api_flavor(flavor)
+            for flavor in self._connection.compute.flavors.all()
+            if not flavor.is_disabled
+        )
         self._log('Found %s flavors', len(flavors))
-        return tuple(self._from_sdk_flavor(f) for f in flavors)
+        return flavors
 
-    @convert_sdk_exceptions
-    @functools.lru_cache()
+    @convert_exceptions
     def find_size(self, id):
         """
         See :py:meth:`.base.ScopedSession.find_size`.
         """
         self._log("Fetching flavor with id '%s'", id)
-        return self._from_sdk_flavor(self._connection.compute.get_flavor(id))
+        return self._from_api_flavor(self._connection.compute.flavors.get(id))
 
-    @functools.lru_cache()
     def _tenant_network(self):
         """
-        Returns the ID of the tenant network connected to the tenant router.
+        Returns the network connected to the tenant router.
         Assumes a single router with a single tenant network connected.
-        Return ``None`` if the tenant network cannot be located.
         """
-        try:
-            port = next(self._connection.network.ports(device_owner = 'network:router_interface'))
-        except StopIteration:
-            raise errors.ImproperlyConfiguredError('Could not find tenancy network')
+        port = self._connection.network.ports.find_by_device_owner('network:router_interface')
+        if port:
+            return self._connection.network.networks.get(port.network_id)
         else:
-            return self._connection.network.find_network(port.network_id)
-
-    class Server(server.Server):
-        """
-        Custom server resource with fault property.
-        """
-        fault = resource.Body('fault', type = dict)
-
-    class ServerDetail(server.ServerDetail):
-        """
-        Custom server detail resource with fault property.
-
-        ``ServerDetail`` extends ``Server`` but with a different API endpoint
-        (``/servers/detail``) that only works when listing. The ``Server``
-        endpoint (``/servers``) only returns id and name for each server.
-        """
-        fault = resource.Body('fault', type = dict)
+            raise errors.ImproperlyConfiguredError('Could not find tenancy network')
 
     _POWER_STATES = {
         0: 'Unknown',
@@ -562,29 +424,29 @@ class ScopedSession(base.ScopedSession):
         7: 'Suspended',
     }
 
-    def _from_sdk_server(self, sdk_server):
+    def _from_api_server(self, api_server):
         """
         See :py:meth:`.base.ScopedSession.find_machine`.
         """
         # Make sure we can find the image and flavor specified
         try:
-            image = self.find_image(sdk_server.image['id'])
-        except (KeyError, errors.ObjectNotFoundError):
+            image = self.find_image(api_server.image.id)
+        except (AttributeError, errors.ObjectNotFoundError):
             image = None
         try:
-            size = self.find_size(sdk_server.flavor['id'])
-        except (KeyError, errors.ObjectNotFoundError):
+            size = self.find_size(api_server.flavor.id)
+        except (AttributeError, errors.ObjectNotFoundError):
             size = None
         # Try to get nat_allowed from the machine metadata
         # If the nat_allowed metadata is not present, use the image
         # If the image does not exist anymore, assume it is allowed
         try:
-            nat_allowed = bool(int(sdk_server.metadata['jasmin_nat_allowed']))
+            nat_allowed = bool(int(api_server.metadata['jasmin_nat_allowed']))
         except (KeyError, TypeError):
             nat_allowed = image.nat_allowed if image else True
-        status = sdk_server.status
-        fault = (sdk_server.fault or {}).get('message', None)
-        task = sdk_server.task_state
+        status = api_server.status
+        fault = api_server.fault.get('message', None)
+        task = api_server.task_state
         # Find IP addresses specifically on the tenant network that is connected
         # to the router
         network = self._tenant_network()
@@ -593,14 +455,14 @@ class ScopedSession(base.ScopedSession):
             return next(
                 (
                     a['addr']
-                    for a in sdk_server.addresses.get(network.name, [])
+                    for a in api_server.addresses.get(network.name, [])
                     if a['version'] == 4 and a['OS-EXT-IPS:type'] == ip_type
                 ),
                 None
             )
         return dto.Machine(
-            sdk_server.id,
-            sdk_server.name,
+            api_server.id,
+            api_server.name,
             image,
             size,
             dto.Machine.Status(
@@ -608,35 +470,38 @@ class ScopedSession(base.ScopedSession):
                 status,
                 _replace_resource_names(fault) if fault else None
             ),
-            self._POWER_STATES[sdk_server.power_state],
+            self._POWER_STATES[api_server.power_state],
             task.capitalize() if task else None,
             ip_of_type('fixed'),
             ip_of_type('floating'),
             nat_allowed,
-            tuple(v['id'] for v in sdk_server.attached_volumes),
-            sdk_server.user_id,
-            dateutil.parser.parse(sdk_server.created_at)
+            tuple(v['id'] for v in api_server.attached_volumes),
+            api_server.user_id,
+            dateutil.parser.parse(api_server.created)
         )
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def machines(self):
         """
         See :py:meth:`.base.ScopedSession.machines`.
         """
         self._log('Fetching available servers')
         # In order to get fault info, we need to use a custom resource definition
-        servers = list(self._connection.compute._list(self.ServerDetail))
+        servers = tuple(
+            self._from_api_server(s)
+            for s in self._connection.compute.servers.all()
+        )
         self._log('Found %s servers', len(servers))
-        return tuple(self._from_sdk_server(s) for s in servers)
+        return servers
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def find_machine(self, id):
         """
         See :py:meth:`.base.ScopedSession.find_machine`.
         """
         # In order to get fault info, we need to use a custom resource definition
         self._log("Fetching server with id '%s'", id)
-        return self._from_sdk_server(self._connection.compute._get(self.Server, id))
+        return self._from_api_server(self._connection.compute.servers.get(id))
 
     def _get_or_create_keypair(self, ssh_key):
         # Keypairs are immutable, i.e. once created cannot be changed
@@ -646,155 +511,162 @@ class ScopedSession(base.ScopedSession):
         fingerprint = hashlib.md5(base64.b64decode(ssh_key.split()[1])).hexdigest()
         key_name = '{}-{}'.format(self._username, fingerprint)
         try:
-            return self._connection.compute.find_keypair(key_name, False)
-        except exceptions.ResourceNotFound:
-            return self._connection.compute.create_keypair(
+            # We need to force a fetch so that the keypair is resolved
+            return self._connection.compute.keypairs.get(key_name, force = True)
+        except rackit.NotFound:
+            return self._connection.compute.keypairs.create(
                 name = key_name,
                 public_key = ssh_key
             )
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def create_machine(self, name, image, size, ssh_key = None):
         """
         See :py:meth:`.base.ScopedSession.create_machine`.
         """
-        # Convert the given image or image ID into an SDK image
-        image = image.id if isinstance(image, dto.Image) else image
-        try:
-            sdk_image = self._find_sdk_image(image)
-        except errors.ObjectNotFoundError:
-            raise errors.BadInputError('Invalid image provided')
+        # If an id was given, resolve it to an image
+        if not isinstance(image, dto.Image):
+            try:
+                image = self.find_image(image)
+            except errors.ObjectNotFoundError:
+                raise errors.BadInputError('Invalid image provided')
+        # To find the metadata elements, we need the raw API image
+        # This will load from the cache
+        api_image = self._connection.image.images.get(image.id)
         size = size.id if isinstance(size, dto.Size) else size
-        self._log("Creating machine '%s' (image: %s, size: %s)", name, sdk_image.name, size)
+        self._log("Creating machine '%s' (image: %s, size: %s)", name, api_image.name, size)
         # Get the networks to use
         networks = [{ 'uuid': self._tenant_network().id }]
         # Only attach the private network if it is defined, exists and the image asks for it
-        attach_private_network = (
-            sdk_image.jasmin_private_if is not None and
-            self._secondary_network_id and
-            self._connection.network.find_network(self._secondary_network_id) is not None
-        )
-        if attach_private_network:
-            networks.append({ 'uuid': self._secondary_network_id })
+        if self._secondary_network_id and getattr(api_image, 'jasmin_private_if', None):
+            secondary_network = self._connection.network.networks.get(
+                self._secondary_network_id,
+                ignore_missing = True
+            )
+            if secondary_network:
+                networks.append({ 'uuid': self._secondary_network_id })
         # Get the keypair to inject
         keypair = self._get_or_create_keypair(ssh_key) if ssh_key else None
         # Pass metadata onto the machine from the image if present
         metadata = dict(jasmin_organisation = self._tenancy.name)
         metadata.update({
-            item : getattr(sdk_image, item)
+            item : getattr(api_image, item)
             for item in {
                 'jasmin_nat_allowed',
                 'jasmin_type',
                 'jasmin_private_if',
                 'jasmin_activ_ver'
             }
-            if getattr(sdk_image, item, None) is not None
+            if getattr(api_image, item, None) is not None
         })
-        server = self._connection.compute.create_server(
+        server = self._connection.compute.servers.create(
             name = name,
-            image_id = sdk_image.id,
+            image_id = api_image.id,
             flavor_id = size,
             networks = networks,
             # Set the instance metadata
             metadata = metadata,
-            # The SDK doesn't like it if None is given for keypair, but behaves
+            # The API doesn't like it if None is given for keypair, but behaves
             # correctly if it is not given at all
             **({ 'key_name': keypair.name } if keypair else {})
         )
         return self.find_machine(server.id)
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def start_machine(self, machine):
         """
         See :py:meth:`.base.ScopedSession.start_machine`.
         """
         machine = machine.id if isinstance(machine, dto.Machine) else machine
         self._log("Starting machine '%s'", machine)
-        self._connection.compute.start_server(machine)
+        self._connection.compute.servers.get(machine).start()
         return self.find_machine(machine)
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def stop_machine(self, machine):
         """
         See :py:meth:`.base.ScopedSession.stop_machine`.
         """
         machine = machine.id if isinstance(machine, dto.Machine) else machine
         self._log("Stopping machine '%s'", machine)
-        self._connection.compute.stop_server(machine)
+        self._connection.compute.servers.get(machine).stop()
         return self.find_machine(machine)
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def restart_machine(self, machine):
         """
         See :py:meth:`.base.ScopedSession.restart_machine`.
         """
         machine = machine.id if isinstance(machine, dto.Machine) else machine
         self._log("Restarting machine '%s'", machine)
-        self._connection.compute.reboot_server(machine, 'SOFT')
+        self._connection.compute.servers.get(machine).reboot('SOFT')
         return self.find_machine(machine)
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def delete_machine(self, machine):
         """
         See :py:meth:`.base.ScopedSession.delete_machine`.
         """
         machine = machine.id if isinstance(machine, dto.Machine) else machine
         self._log("Deleting machine '%s'", machine)
-        self._connection.compute.delete_server(machine)
+        self._connection.compute.servers.delete(machine)
         try:
             return self.find_machine(machine)
         except errors.ObjectNotFoundError:
             return None
 
-    def _from_sdk_floatingip(self, sdk_floatingip):
+    def _from_api_floatingip(self, api_floatingip):
         """
-        Converts an OpenStack SDK floatingip object into a :py:class:`.dto.ExternalIp`.
+        Converts an OpenStack API floatingip object into a :py:class:`.dto.ExternalIp`.
         """
-        if sdk_floatingip.port_id:
-            port = self._connection.network.find_port(sdk_floatingip.port_id)
+        if api_floatingip.port_id:
+            port = self._connection.network.ports.get(api_floatingip.port_id)
             machine_id = port.device_id
         else:
             machine_id = None
-        return dto.ExternalIp(sdk_floatingip.floating_ip_address, machine_id)
+        return dto.ExternalIp(api_floatingip.floating_ip_address, machine_id)
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def external_ips(self):
         """
         See :py:meth:`.base.ScopedSession.external_ips`.
         """
         self._log("Fetching floating ips")
-        fips = list(self._connection.network.ips())
+        fips = tuple(
+            self._from_api_floatingip(fip)
+            for fip in self._connection.network.floatingips.all()
+        )
         self._log("Found %s floating ips", len(fips))
-        return tuple(self._from_sdk_floatingip(fip) for fip in fips)
+        return fips
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def allocate_external_ip(self):
         """
         See :py:meth:`.base.ScopedSession.allocate_external_ip`.
         """
         self._log("Allocating new floating ip")
         # Get the external network being used by the tenancy router
-        router = next(self._connection.network.routers(), None)
+        router = next(self._connection.network.routers.all(), None)
         if not router:
             raise errors.ImproperlyConfiguredError('Could not find tenancy router.')
         extnet = router.external_gateway_info['network_id']
         # Create a new floating IP on that network
-        fip = self._connection.network.create_ip(floating_network_id = extnet)
+        fip = self._connection.network.floatingips.create(floating_network_id = extnet)
         self._log("Allocated new floating ip '%s'", fip.floating_ip_address)
-        return self._from_sdk_floatingip(fip)
+        return self._from_api_floatingip(fip)
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def find_external_ip(self, ip):
         """
         See :py:meth:`.base.ScopedSession.find_external_ip`.
         """
         self._log("Fetching floating IP details for '%s'", ip)
-        fip = next(self._connection.network.ips(floating_ip_address = ip), None)
+        fip = self._connection.network.floatingips.find_by_floating_ip_address(ip)
         if not fip:
             raise errors.ObjectNotFoundError("Could not find external IP '{}'".format(ip))
-        return self._from_sdk_floatingip(fip)
+        return self._from_api_floatingip(fip)
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def attach_external_ip(self, ip, machine):
         """
         See :py:meth:`.base.ScopedSession.attach_external_ip`.
@@ -810,8 +682,10 @@ class ScopedSession(base.ScopedSession):
         # Get the port that attaches the machine to the tenant network
         tenant_net = self._tenant_network()
         port = next(
-            self._connection.network.ports(device_id = machine.id,
-                                          network_id = tenant_net.id),
+            self._connection.network.ports.all(
+                device_id = machine.id,
+                network_id = tenant_net.id
+            ),
             None
         )
         if not port:
@@ -819,19 +693,17 @@ class ScopedSession(base.ScopedSession):
                 'Machine is not connected to tenancy network.'
             )
         # If there is already a floating IP associated with the port, detach it
-        current = next(self._connection.network.ips(port_id = port.id), None)
+        current = self._connection.network.floatingips.find_by_port_id(port.id)
         if current:
-            self._connection.network.update_ip(current, port_id = None)
+            current._update(port_id = None)
         # Find the floating IP instance for the given address
-        fip = next(self._connection.network.ips(floating_ip_address = ip), None)
+        fip = self._connection.network.floatingips.find_by_floating_ip_address(ip)
         if not fip:
             raise errors.ObjectNotFoundError("Could not find external IP '{}'".format(ip))
         # Associate the floating IP with the port
-        return self._from_sdk_floatingip(
-            self._connection.network.update_ip(fip, port_id = port.id)
-        )
+        return self._from_api_floatingip(fip._update(port_id = port.id))
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def detach_external_ip(self, ip):
         """
         See :py:meth:`.base.ScopedSession.detach_external_ip`.
@@ -839,13 +711,11 @@ class ScopedSession(base.ScopedSession):
         ip = ip.external_ip if isinstance(ip, dto.ExternalIp) else ip
         self._log("Detaching floating ip '%s'", ip)
         # Find the floating IP instance for the given address
-        fip = next(self._connection.network.ips(floating_ip_address = ip), None)
+        fip = self._connection.network.floatingips.find_by_floating_ip_address(ip)
         if not fip:
             raise errors.ObjectNotFoundError("Could not find external IP '{}'".format(ip))
         # Remove any association for the floating IP
-        return self._from_sdk_floatingip(
-            self._connection.network.update_ip(fip, port_id = None)
-        )
+        return self._from_api_floatingip(fip._update(port_id = None))
 
     _VOLUME_STATUSES = {
         'creating': dto.Volume.Status.CREATING,
@@ -862,58 +732,61 @@ class ScopedSession(base.ScopedSession):
         'error_extending': dto.Volume.Status.ERROR,
     }
 
-    def _from_sdk_volume(self, sdk_volume):
+    def _from_api_volume(self, api_volume):
         """
         Converts an OpenStack SDK volume object into a :py:class:`.dto.Volume`.
         """
         # Work out the volume status
         status = self._VOLUME_STATUSES.get(
-            sdk_volume.status.lower(),
+            api_volume.status.lower(),
             dto.Volume.Status.OTHER
         )
         try:
-            attachment = sdk_volume.attachments[0]
+            attachment = api_volume.attachments[0]
         except IndexError:
             attachment = None
         return dto.Volume(
-            sdk_volume.id,
+            api_volume.id,
             # If there is no name, use part of the ID
-            sdk_volume.name or sdk_volume.id[:13],
+            api_volume.name or api_volume.id[:13],
             status,
-            sdk_volume.size,
+            api_volume.size,
             attachment['server_id'] if attachment else None,
             attachment['device'] if attachment else None
         )
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def volumes(self):
         """
         See :py:meth:`.base.ScopedSession.volumes`.
         """
         self._log('Fetching available volumes')
-        volumes = list(self._connection.block_store.volumes())
+        volumes = tuple(
+            self._from_api_volume(v)
+            for v in self._connection.block_store.volumes.all()
+        )
         self._log('Found %s volumes', len(volumes))
-        return tuple(self._from_sdk_volume(v) for v in volumes)
+        return volumes
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def find_volume(self, id):
         """
         See :py:meth:`.base.ScopedSession.find_volume`.
         """
         self._log("Fetching volume with id '%s'", id)
-        volume = self._connection.block_store.get_volume(id)
-        return self._from_sdk_volume(volume)
+        volume = self._connection.block_store.volumes.get(id)
+        return self._from_api_volume(volume)
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def create_volume(self, name, size):
         """
         See :py:meth:`.base.ScopedSession.create_volume`.
         """
-        self._log("Creating machine '%s' (size: %s)", name, size)
-        volume = self._connection.block_store.create_volume(name = name, size = size)
+        self._log("Creating volume '%s' (size: %s)", name, size)
+        volume = self._connection.block_store.volumes.create(name = name, size = size)
         return self.find_volume(volume.id)
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def delete_volume(self, volume):
         """
         See :py:meth:`.base.ScopedSession.delete_volume`.
@@ -924,13 +797,13 @@ class ScopedSession(base.ScopedSession):
                 "Cannot delete volume with status {}.".format(volume.status.name)
             )
         self._log("Deleting volume '%s'", volume.id)
-        self._connection.block_store.delete_volume(volume.id)
+        self._connection.block_store.volumes.delete(volume.id)
         try:
             return self.find_volume(volume.id)
         except errors.ObjectNotFoundError:
             return None
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def attach_volume(self, volume, machine):
         """
         See :py:meth:`.base.ScopedSession.attach_volume`.
@@ -946,13 +819,13 @@ class ScopedSession(base.ScopedSession):
                 "Volume must be AVAILABLE before attaching."
             )
         self._log("Attaching volume '%s' to server '%s'", volume.id, machine)
-        self._connection.compute.create_volume_attachment(
-            machine,
-            volume_id = volume.id
-        )
+        server = self._connection.compute.servers.get(machine)
+        server.volume_attachments.create(volume_id = volume.id)
+        # Refresh the volume in the cache
+        self._connection.block_store.volumes.get(volume.id, force = True)
         return self.find_volume(volume.id)
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def detach_volume(self, volume):
         """
         See :py:meth:`.base.ScopedSession.detach_volume`.
@@ -962,7 +835,10 @@ class ScopedSession(base.ScopedSession):
         if not volume.machine_id:
             return volume
         self._log("Detaching volume '%s' from '%s'", volume.id, volume.machine_id)
-        self._connection.compute.delete_volume_attachment(volume.id, volume.machine_id)
+        server = self._connection.compute.servers.get(volume.machine_id)
+        server.volume_attachments.find_by_volume_id(volume.id, as_params = False)._delete()
+        # Refresh the volume in the cache
+        self._connection.block_store.volumes.get(volume.id, force = True)
         return self.find_volume(volume.id)
 
     @property
@@ -986,14 +862,14 @@ class ScopedSession(base.ScopedSession):
             )
         return self._cluster_manager
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def cluster_types(self):
         """
         See :py:meth:`.base.ScopedSession.cluster_types`.
         """
         return self.cluster_manager.cluster_types()
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def find_cluster_type(self, name):
         """
         See :py:meth:`.base.ScopedSession.find_cluster_type`.
@@ -1011,10 +887,10 @@ class ScopedSession(base.ScopedSession):
             if k != 'cluster_network'
         }
         # Add any tags attached to the stack
-        stack = self._connection.orchestration.find_stack(
-            cluster.name,
-            ignore_missing = True
-        )
+        try:
+            stack = self._connection.orchestration.stacks.find_by_stack_name(cluster.name)
+        except rackit.NotFound:
+            stack = None
         # We use this format because tags might exist on the stack but be None
         stack_tags = tuple(getattr(stack, 'tags', None) or [])
         original_error = (cluster.error_message or '').lower()
@@ -1043,7 +919,7 @@ class ScopedSession(base.ScopedSession):
             error_message = error_message
         )
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def clusters(self):
         """
         See :py:meth:`.base.ScopedSession.clusters`.
@@ -1053,7 +929,7 @@ class ScopedSession(base.ScopedSession):
             for c in self.cluster_manager.clusters()
         )
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def find_cluster(self, id):
         """
         See :py:meth:`.base.ScopedSession.find_cluster`.
@@ -1063,16 +939,13 @@ class ScopedSession(base.ScopedSession):
         )
 
     def _cluster_credential(self):
-        # Making sure we get the public URL for identity is a bit contrived
-        session = self._connection.session
-        auth_ref = session.auth.get_auth_ref(session)
         return dict(
-            auth_url = auth_ref.service_catalog.url_for('identity', 'public'),
-            project_id = self._connection.current_project.id,
-            token = self._connection.authorize()
+            auth_url = self._connection.auth_url,
+            project_id = self._connection.project_id,
+            token = self._connection.token
         )
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def create_cluster(self, name, cluster_type, params, ssh_key):
         """
         See :py:meth:`.base.ScopedSession.create_cluster`.
@@ -1090,7 +963,7 @@ class ScopedSession(base.ScopedSession):
             )
         )
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def update_cluster(self, cluster, params):
         """
         See :py:meth:`.base.ScopedSession.update_cluster`.
@@ -1109,7 +982,7 @@ class ScopedSession(base.ScopedSession):
             )
         )
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def patch_cluster(self, cluster):
         """
         See :py:meth:`.base.ScopedSession.patch_cluster`.
@@ -1121,7 +994,7 @@ class ScopedSession(base.ScopedSession):
             )
         )
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def delete_cluster(self, cluster):
         """
         See :py:meth:`.base.ScopedSession.delete_cluster`.
@@ -1133,13 +1006,13 @@ class ScopedSession(base.ScopedSession):
             )
         )
 
-    @convert_sdk_exceptions
+    @convert_exceptions
     def close(self):
         """
         See :py:meth:`.base.ScopedSession.close`.
         """
-        # Make sure the underlying OpenStack connection is closed
-        close_openstack_connection(self._connection)
+        # Make sure the underlying api connection is closed
+        self._connection.close()
         # Also close the cluster manager if one has been created
         if getattr(self, '_cluster_manager', None):
             self._cluster_manager.close()

--- a/jasmin_cloud/settings.py
+++ b/jasmin_cloud/settings.py
@@ -20,6 +20,11 @@ class JasminCloudSettings(SettingsObject):
     PROVIDER = ObjectFactorySetting()
     #: SSH key store configuration
     SSH_KEY_STORE = ObjectFactorySetting()
+    #: The clouds that are available
+    #: Should be a mapping of name => (label, url) dictionaries
+    AVAILABLE_CLOUDS = Setting()
+    #: The name of the current cloud
+    CURRENT_CLOUD = Setting()
 
 
 cloud_settings = JasminCloudSettings('JASMIN_CLOUD')

--- a/jasmin_cloud/settings.py
+++ b/jasmin_cloud/settings.py
@@ -13,6 +13,9 @@ class JasminCloudSettings(SettingsObject):
     """
     #: The name of the cookie used to store tokens
     TOKEN_COOKIE_NAME = Setting(default = 'provider-token')
+    #: Indicates whether the token cookie should be restricted to secure connections
+    #: Should always be True in production
+    TOKEN_COOKIE_SECURE = Setting(default = True)
     #: Cloud provider configuration
     PROVIDER = ObjectFactorySetting()
     #: SSH key store configuration

--- a/jasmin_cloud/urls.py
+++ b/jasmin_cloud/urls.py
@@ -9,6 +9,7 @@ from . import views
 
 app_name = 'jasmin_cloud'
 urlpatterns = [
+    path('', views.cloud_info, name = 'cloud_info'),
     path('authenticate/', views.authenticate, name = 'authenticate'),
     path('session/', views.session, name = 'session'),
     path('tenancies/', views.tenancies, name = 'tenancies'),

--- a/jasmin_cloud/views.py
+++ b/jasmin_cloud/views.py
@@ -169,7 +169,7 @@ def session(request):
     """
     if request.method == 'DELETE':
         request.provider_session.close()
-        del request.provider_session
+        request.provider_session = None
         return response.Response()
     else:
         return response.Response({

--- a/jasmin_cloud/views.py
+++ b/jasmin_cloud/views.py
@@ -123,6 +123,8 @@ def provider_api_view(methods):
 
 
 @decorators.api_view(['POST'])
+# No authentication is required for this endpoint
+@decorators.authentication_classes([])
 @convert_provider_exceptions
 def authenticate(request):
     """

--- a/jasmin_cloud/views.py
+++ b/jasmin_cloud/views.py
@@ -10,7 +10,7 @@ from django.utils.encoding import smart_text
 
 from docutils import core
 
-from rest_framework import decorators, response, status, exceptions as drf_exceptions
+from rest_framework import decorators, permissions, response, status, exceptions as drf_exceptions
 from rest_framework.utils import formatting
 
 from . import serializers
@@ -92,42 +92,37 @@ def convert_provider_exceptions(view):
     return wrapper
 
 
-def map_provider_session(view):
-    """
-    Decorator that copies the provider session between the DRF request and Django request.
-
-    DRF uses it's own request object that wraps the Django request, but doesn't map
-    custom properties, like the provider session set by our middleware.
-    """
-    @functools.wraps(view)
-    def wrapper(request, *args, **kwargs):
-        # Copy the session onto the DRF request from the wrapped request
-        request.provider_session = getattr(request._request, 'provider_session', None)
-        # Resolve the response
-        response = view(request, *args, **kwargs)
-        # Copy the current value of the provider session back onto the wrapped request
-        request._request.provider_session = getattr(request, 'provider_session', None)
-        return response
-    return wrapper
-
-
 def require_provider_session(view):
     """
     Decorator that requires that a provider session is available on the request object.
     """
     @functools.wraps(view)
     def wrapper(request, *args, **kwargs):
-        if not request.provider_session:
+        # The provider session will be set as the auth parameter on the request
+        # This is populated by our authentication class if the authentication passed
+        session = getattr(request, 'auth', None)
+        if not session:
             # If there is no provider session, force a reauthentication
             raise drf_exceptions.NotAuthenticated
         # Return the response
         return view(request, *args, **kwargs)
-    # Wrap the returned view with map_provider_session
-    return map_provider_session(wrapper)
+    return wrapper
+
+
+def provider_api_view(methods):
+    """
+    Returns a decorator for a provider API view that combines several decorators into one.
+    """
+    def decorator(view):
+        view = convert_provider_exceptions(view)
+#        view = require_provider_session(view)
+        view = decorators.permission_classes([permissions.IsAuthenticated])(view)
+        view = decorators.api_view(methods)(view)
+        return view
+    return decorator
 
 
 @decorators.api_view(['POST'])
-@map_provider_session
 @convert_provider_exceptions
 def authenticate(request):
     """
@@ -148,19 +143,17 @@ def authenticate(request):
     # Attempt to authenticate the user with the configured provider
     # Let the authentication error bubble to be handled by the decorator
     # Add the session to the request to be used by the middleware
-    request.provider_session = cloud_settings.PROVIDER.authenticate(username, password)
+    request.auth = cloud_settings.PROVIDER.authenticate(username, password)
     return response.Response({
-        'username': request.provider_session.username(),
-        'token': request.provider_session.token(),
+        'username': request.auth.username(),
+        'token': request.auth.token(),
         'links': {
             'tenancies': request.build_absolute_uri(reverse('jasmin_cloud:tenancies'))
         }
     })
 
 
-@decorators.api_view(['GET', 'DELETE'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['GET', 'DELETE'])
 def session(request):
     """
     On ``GET`` requests, return information about the current session.
@@ -168,42 +161,38 @@ def session(request):
     On ``DELETE`` requests, destroy the current session.
     """
     if request.method == 'DELETE':
-        request.provider_session.close()
-        request.provider_session = None
+        request.auth.close()
+        request.auth = None
         return response.Response()
     else:
         return response.Response({
-            'username': request.provider_session.username(),
-            'token': request.provider_session.token(),
+            'username': request.auth.username(),
+            'token': request.auth.token(),
             'links': {
                 'tenancies': request.build_absolute_uri(reverse('jasmin_cloud:tenancies'))
             }
         })
 
 
-@decorators.api_view(['GET'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['GET'])
 def tenancies(request):
     """
     Returns the tenancies available to the authenticated user.
     """
     serializer = serializers.TenancySerializer(
-        request.provider_session.tenancies(),
+        request.auth.tenancies(),
         many = True,
         context = { 'request': request }
     )
     return response.Response(serializer.data)
 
 
-@decorators.api_view(['GET'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['GET'])
 def quotas(request, tenant):
     """
     Returns information about the quotas available to the tenant.
     """
-    with request.provider_session.scoped_session(tenant) as session:
+    with request.auth.scoped_session(tenant) as session:
         serializer = serializers.QuotaSerializer(
             session.quotas(),
             many = True,
@@ -212,9 +201,7 @@ def quotas(request, tenant):
     return response.Response(serializer.data)
 
 
-@decorators.api_view(['GET'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['GET'])
 def images(request, tenant):
     """
     Returns the images available to the specified tenancy.
@@ -226,7 +213,7 @@ def images(request, tenant):
     * ``is_public``: Indicates if the image is public or private.
     * ``nat_allowed``: Indicates if NAT is allowed for machines deployed from the image.
     """
-    with request.provider_session.scoped_session(tenant) as session:
+    with request.auth.scoped_session(tenant) as session:
         serializer = serializers.ImageSerializer(
             session.images(),
             many = True,
@@ -235,9 +222,7 @@ def images(request, tenant):
     return response.Response(serializer.data)
 
 
-@decorators.api_view(['GET'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['GET'])
 def image_details(request, tenant, image):
     """
     Returns the details for the specified image.
@@ -249,7 +234,7 @@ def image_details(request, tenant, image):
     * ``is_public``: Indicates if the image is public or private.
     * ``nat_allowed``: Indicates if NAT is allowed for machines deployed from the image.
     """
-    with request.provider_session.scoped_session(tenant) as session:
+    with request.auth.scoped_session(tenant) as session:
         serializer = serializers.ImageSerializer(
             session.find_image(image),
             context = { 'request': request, 'tenant': tenant }
@@ -257,9 +242,7 @@ def image_details(request, tenant, image):
     return response.Response(serializer.data)
 
 
-@decorators.api_view(['GET'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['GET'])
 def sizes(request, tenant):
     """
     Returns the machine sizes available to the specified tenancy.
@@ -271,7 +254,7 @@ def sizes(request, tenant):
     * ``cpus``: The number of CPUs.
     * ``ram``: The amount of RAM (in MB).
     """
-    with request.provider_session.scoped_session(tenant) as session:
+    with request.auth.scoped_session(tenant) as session:
         serializer = serializers.SizeSerializer(
             session.sizes(),
             many = True,
@@ -280,9 +263,7 @@ def sizes(request, tenant):
     return response.Response(serializer.data)
 
 
-@decorators.api_view(['GET'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['GET'])
 def size_details(request, tenant, size):
     """
     Returns the details for the specified machine size.
@@ -294,7 +275,7 @@ def size_details(request, tenant, size):
     * ``cpus``: The number of CPUs.
     * ``ram``: The amount of RAM (in MB).
     """
-    with request.provider_session.scoped_session(tenant) as session:
+    with request.auth.scoped_session(tenant) as session:
         serializer = serializers.SizeSerializer(
             session.find_size(size),
             context = { 'request': request, 'tenant': tenant }
@@ -302,9 +283,7 @@ def size_details(request, tenant, size):
     return response.Response(serializer.data)
 
 
-@decorators.api_view(['GET', 'POST'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['GET', 'POST'])
 def machines(request, tenant):
     """
     On ``GET`` requests, return the machines deployed in the specified tenancy.
@@ -320,7 +299,7 @@ def machines(request, tenant):
     if request.method == 'POST':
         input_serializer = serializers.MachineSerializer(data = request.data)
         input_serializer.is_valid(raise_exception = True)
-        with request.provider_session.scoped_session(tenant) as session:
+        with request.auth.scoped_session(tenant) as session:
             output_serializer = serializers.MachineSerializer(
                 session.create_machine(
                     input_serializer.validated_data['name'],
@@ -332,7 +311,7 @@ def machines(request, tenant):
             )
         return response.Response(output_serializer.data, status = status.HTTP_201_CREATED)
     else:
-        with request.provider_session.scoped_session(tenant) as session:
+        with request.auth.scoped_session(tenant) as session:
             serializer = serializers.MachineSerializer(
                 session.machines(),
                 many = True,
@@ -341,9 +320,7 @@ def machines(request, tenant):
         return response.Response(serializer.data)
 
 
-@decorators.api_view(['GET', 'DELETE'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['GET', 'DELETE'])
 def machine_details(request, tenant, machine):
     """
     On ``GET`` requests, return the details for the specified machine.
@@ -351,7 +328,7 @@ def machine_details(request, tenant, machine):
     On ``DELETE`` requests, delete the specified machine.
     """
     if request.method == 'DELETE':
-        with request.provider_session.scoped_session(tenant) as session:
+        with request.auth.scoped_session(tenant) as session:
             deleted = session.delete_machine(machine)
         if deleted:
             serializer = serializers.MachineSerializer(
@@ -362,7 +339,7 @@ def machine_details(request, tenant, machine):
         else:
             return response.Response()
     else:
-        with request.provider_session.scoped_session(tenant) as session:
+        with request.auth.scoped_session(tenant) as session:
             serializer = serializers.MachineSerializer(
                 session.find_machine(machine),
                 context = { 'request': request, 'tenant': tenant }
@@ -370,14 +347,12 @@ def machine_details(request, tenant, machine):
         return response.Response(serializer.data)
 
 
-@decorators.api_view(['POST'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['POST'])
 def machine_start(request, tenant, machine):
     """
     Start (power on) the specified machine.
     """
-    with request.provider_session.scoped_session(tenant) as session:
+    with request.auth.scoped_session(tenant) as session:
         serializer = serializers.MachineSerializer(
             session.start_machine(machine),
             context = { 'request': request, 'tenant': tenant }
@@ -385,14 +360,12 @@ def machine_start(request, tenant, machine):
     return response.Response(serializer.data)
 
 
-@decorators.api_view(['POST'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['POST'])
 def machine_stop(request, tenant, machine):
     """
     Stop (power off) the specified machine.
     """
-    with request.provider_session.scoped_session(tenant) as session:
+    with request.auth.scoped_session(tenant) as session:
         serializer = serializers.MachineSerializer(
             session.stop_machine(machine),
             context = { 'request': request, 'tenant': tenant }
@@ -400,14 +373,12 @@ def machine_stop(request, tenant, machine):
     return response.Response(serializer.data)
 
 
-@decorators.api_view(['POST'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['POST'])
 def machine_restart(request, tenant, machine):
     """
     Restart (power cycle) the specified machine.
     """
-    with request.provider_session.scoped_session(tenant) as session:
+    with request.auth.scoped_session(tenant) as session:
         serializer = serializers.MachineSerializer(
             session.restart_machine(machine),
             context = { 'request': request, 'tenant': tenant }
@@ -415,9 +386,7 @@ def machine_restart(request, tenant, machine):
     return response.Response(serializer.data)
 
 
-@decorators.api_view(['GET', 'POST'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['GET', 'POST'])
 def external_ips(request, tenant):
     """
     On ``GET`` requests, return a list of external IP addresses that are
@@ -433,11 +402,11 @@ def external_ips(request, tenant):
         }
     """
     if request.method == 'POST':
-        with request.provider_session.scoped_session(tenant) as session:
+        with request.auth.scoped_session(tenant) as session:
             serializer = serializers.ExternalIPSerializer(session.allocate_external_ip())
         return response.Response(serializer.data, status = status.HTTP_201_CREATED)
     else:
-        with request.provider_session.scoped_session(tenant) as session:
+        with request.auth.scoped_session(tenant) as session:
             serializer = serializers.ExternalIPSerializer(
                 session.external_ips(),
                 many = True,
@@ -446,9 +415,7 @@ def external_ips(request, tenant):
         return response.Response(serializer.data)
 
 
-@decorators.api_view(['GET', 'PUT'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['GET', 'PUT'])
 def external_ip_details(request, tenant, ip):
     """
     On ``GET`` requests, return the details for the external IP address.
@@ -464,7 +431,7 @@ def external_ip_details(request, tenant, ip):
         input_serializer = serializers.ExternalIPSerializer(data = request.data)
         input_serializer.is_valid(raise_exception = True)
         machine_id = input_serializer.validated_data['machine_id']
-        with request.provider_session.scoped_session(tenant) as session:
+        with request.auth.scoped_session(tenant) as session:
             if machine_id:
                 ip = session.attach_external_ip(ip, str(machine_id))
             else:
@@ -475,7 +442,7 @@ def external_ip_details(request, tenant, ip):
         )
         return response.Response(output_serializer.data)
     else:
-        with request.provider_session.scoped_session(tenant) as session:
+        with request.auth.scoped_session(tenant) as session:
             serializer = serializers.ExternalIPSerializer(
                 session.find_external_ip(ip),
                 context = { 'request': request, 'tenant': tenant }
@@ -483,9 +450,7 @@ def external_ip_details(request, tenant, ip):
         return response.Response(serializer.data)
 
 
-@decorators.api_view(['GET', 'POST'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['GET', 'POST'])
 def volumes(request, tenant):
     """
     On ``GET`` requests, return a list of the volumes for the tenancy.
@@ -502,7 +467,7 @@ def volumes(request, tenant):
     if request.method == 'POST':
         input_serializer = serializers.CreateVolumeSerializer(data = request.data)
         input_serializer.is_valid(raise_exception = True)
-        with request.provider_session.scoped_session(tenant) as session:
+        with request.auth.scoped_session(tenant) as session:
             output_serializer = serializers.VolumeSerializer(
                 session.create_volume(
                     input_serializer.validated_data['name'],
@@ -512,7 +477,7 @@ def volumes(request, tenant):
             )
         return response.Response(output_serializer.data, status = status.HTTP_201_CREATED)
     else:
-        with request.provider_session.scoped_session(tenant) as session:
+        with request.auth.scoped_session(tenant) as session:
             serializer = serializers.VolumeSerializer(
                 session.volumes(),
                 many = True,
@@ -521,9 +486,7 @@ def volumes(request, tenant):
         return response.Response(serializer.data)
 
 
-@decorators.api_view(['GET', 'PUT', 'DELETE'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['GET', 'PUT', 'DELETE'])
 def volume_details(request, tenant, volume):
     """
     On ``GET`` requests, return the details for the specified volume.
@@ -545,7 +508,7 @@ def volume_details(request, tenant, volume):
         input_serializer = serializers.UpdateVolumeSerializer(data = request.data)
         input_serializer.is_valid(raise_exception = True)
         machine_id = input_serializer.validated_data['machine_id']
-        with request.provider_session.scoped_session(tenant) as session:
+        with request.auth.scoped_session(tenant) as session:
             if machine_id:
                 volume = session.attach_volume(volume, str(machine_id))
             else:
@@ -556,7 +519,7 @@ def volume_details(request, tenant, volume):
         )
         return response.Response(output_serializer.data)
     elif request.method == 'DELETE':
-        with request.provider_session.scoped_session(tenant) as session:
+        with request.auth.scoped_session(tenant) as session:
             deleted = session.delete_volume(volume)
         if deleted:
             serializer = serializers.VolumeSerializer(
@@ -567,7 +530,7 @@ def volume_details(request, tenant, volume):
         else:
             return response.Response()
     else:
-        with request.provider_session.scoped_session(tenant) as session:
+        with request.auth.scoped_session(tenant) as session:
             serializer = serializers.VolumeSerializer(
                 session.find_volume(volume),
                 context = { 'request': request, 'tenant': tenant }
@@ -575,14 +538,12 @@ def volume_details(request, tenant, volume):
         return response.Response(serializer.data)
 
 
-@decorators.api_view(['GET'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['GET'])
 def cluster_types(request, tenant):
     """
     Returns the cluster types available to the tenancy.
     """
-    with request.provider_session.scoped_session(tenant) as session:
+    with request.auth.scoped_session(tenant) as session:
         serializer = serializers.ClusterTypeSerializer(
             session.cluster_types(),
             many = True,
@@ -591,14 +552,12 @@ def cluster_types(request, tenant):
     return response.Response(serializer.data)
 
 
-@decorators.api_view(['GET'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['GET'])
 def cluster_type_details(request, tenant, cluster_type):
     """
     Returns the requested cluster type.
     """
-    with request.provider_session.scoped_session(tenant) as session:
+    with request.auth.scoped_session(tenant) as session:
         serializer = serializers.ClusterTypeSerializer(
             session.find_cluster_type(cluster_type),
             context = { 'request': request, 'tenant': tenant }
@@ -606,9 +565,7 @@ def cluster_type_details(request, tenant, cluster_type):
     return response.Response(serializer.data)
 
 
-@decorators.api_view(['GET', 'POST'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['GET', 'POST'])
 def clusters(request, tenant):
     """
     On ``GET`` requests, return a list of the deployed clusters.
@@ -616,7 +573,7 @@ def clusters(request, tenant):
     On ``POST`` requests, create a new cluster.
     """
     if request.method == 'POST':
-        with request.provider_session.scoped_session(tenant) as session:
+        with request.auth.scoped_session(tenant) as session:
             input_serializer = serializers.CreateClusterSerializer(
                 data = request.data,
                 context = { 'session': session }
@@ -634,7 +591,7 @@ def clusters(request, tenant):
         )
         return response.Response(output_serializer.data)
     else:
-        with request.provider_session.scoped_session(tenant) as session:
+        with request.auth.scoped_session(tenant) as session:
             serializer = serializers.ClusterSerializer(
                 session.clusters(),
                 many = True,
@@ -643,9 +600,7 @@ def clusters(request, tenant):
         return response.Response(serializer.data)
 
 
-@decorators.api_view(['GET', 'PUT', 'DELETE'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['GET', 'PUT', 'DELETE'])
 def cluster_details(request, tenant, cluster):
     """
     On ``GET`` requests, return the named cluster.
@@ -655,7 +610,7 @@ def cluster_details(request, tenant, cluster):
     On ``DELETE`` requests, delete the named cluster.
     """
     if request.method == 'PUT':
-        with request.provider_session.scoped_session(tenant) as session:
+        with request.auth.scoped_session(tenant) as session:
             cluster = session.find_cluster(cluster)
             input_serializer = serializers.UpdateClusterSerializer(
                 data = request.data,
@@ -672,7 +627,7 @@ def cluster_details(request, tenant, cluster):
         )
         return response.Response(output_serializer.data)
     elif request.method == 'DELETE':
-        with request.provider_session.scoped_session(tenant) as session:
+        with request.auth.scoped_session(tenant) as session:
             deleted = session.delete_cluster(cluster)
         if deleted:
             serializer = serializers.ClusterSerializer(
@@ -683,7 +638,7 @@ def cluster_details(request, tenant, cluster):
         else:
             return response.Response()
     else:
-        with request.provider_session.scoped_session(tenant) as session:
+        with request.auth.scoped_session(tenant) as session:
             serializer = serializers.ClusterSerializer(
                 session.find_cluster(cluster),
                 context = { 'request': request, 'tenant': tenant }
@@ -691,14 +646,12 @@ def cluster_details(request, tenant, cluster):
         return response.Response(serializer.data)
 
 
-@decorators.api_view(['POST'])
-@require_provider_session
-@convert_provider_exceptions
+@provider_api_view(['POST'])
 def cluster_patch(request, tenant, cluster):
     """
     Patch the given cluster.
     """
-    with request.provider_session.scoped_session(tenant) as session:
+    with request.auth.scoped_session(tenant) as session:
         serializer = serializers.ClusterSerializer(
             session.patch_cluster(cluster),
             context = { 'request': request, 'tenant': tenant }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,37 +1,20 @@
-appdirs==1.4.3
 asgiref==3.2.7
 certifi==2020.4.5.1
-cffi==1.14.0
 chardet==3.0.4
-cryptography==2.9
-decorator==4.4.2
-Django==3.0.5
--e git+https://github.com/cedadev/django-settings-object.git@ea07d76f1715e115e178b923e984d2b84f2a2675#egg=django_settings_object
+Django==3.0.6
+-e git+https://github.com/cedadev/django-settings-object.git@01351828ae73cea07404de0a38d5d868ecb75b59#egg=django_settings_object
 djangorestframework==3.11.0
 docutils==0.16
-dogpile.cache==0.9.0
 idna==2.9
-iso8601==0.1.12
 -e git+https://github.com/cedadev/jasmin-ldap.git@ad21e8f7d8d82e33e5bf48820bf5f9e630a53d8d#egg=jasmin_ldap
-jmespath==0.9.5
-jsonpatch==1.25
-jsonpointer==2.0
-keystoneauth1==4.0.0
 ldap3==2.7
-munch==2.5.0
-netifaces==0.10.9
-openstacksdk==0.26.0
-os-service-types==1.7.0
-pbr==5.4.5
 pyasn1==0.4.8
-pycparser==2.20
 python-dateutil==2.8.1
-pytz==2019.3
+pytz==2020.1
 PyYAML==5.3.1
+-e git+https://github.com/cedadev/rackit.git@dc510955e2bd37220ab6a7f4b1ea71432aa48314#egg=rackit
 requests==2.23.0
-requestsexceptions==1.4.0
 six==1.14.0
 sqlparse==0.3.1
-stevedore==1.32.0
-urllib3==1.25.8
+urllib3==1.25.9
 voluptuous==0.11.7

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ if __name__ == "__main__":
         install_requires = [
             'docutils',
             'python-dateutil',
-            'openstacksdk<0.27.0',  # https://storyboard.openstack.org/#!/story/2006343
             'django',
             'djangorestframework',
             'django-settings-object',
@@ -39,5 +38,6 @@ if __name__ == "__main__":
             'pyyaml',
             'voluptuous',
             'requests',
+            'rackit',
         ],
     )


### PR DESCRIPTION
This PR adds the capability for setting a vNIC type when attaching a VM to the backdoor network. This will allow machines to be created with SR-IOV enabled which should improve storage performance.

It also replaces the OpenStack SDK with a custom client. The OpenStack SDK has been stuck on a very old version for a long term as it proved difficult to update, and there are a number of places where we had to dip out of the SDK anyway, which is difficult.