### PR TITLE
Preventing port removal for CaaS machines

### DIFF
--- a/jasmin_cloud/provider/dto.py
+++ b/jasmin_cloud/provider/dto.py
@@ -75,7 +75,7 @@ class Size(namedtuple('Size', ['id', 'name', 'cpus', 'ram', 'disk'])):
 class Machine(namedtuple('Machine', ['id', 'name', 'image', 'size',
                                      'status', 'power_state', 'task',
                                      'internal_ip', 'external_ip', 'nat_allowed',
-                                     'attached_volume_ids', 'owner', 'created'])):
+                                     'attached_volume_ids', 'owner', 'created', 'previsioned_by_caas'])):
     """
     Represents a machine in a tenancy.
 
@@ -93,6 +93,7 @@ class Machine(namedtuple('Machine', ['id', 'name', 'image', 'size',
         attached_volume_ids: A tuple of ids of attached volumes for the machine.
         owner: The username of the user who deployed the machine.
         created: The `datetime` at which the machine was deployed.
+        previsioned_by_caas: 1 if the machine was previsioned by caas, 0 otherwise.
     """
     class Status(namedtuple('Status', ['type', 'name', 'details'])):
         """

--- a/jasmin_cloud/provider/openstack/provider.py
+++ b/jasmin_cloud/provider/openstack/provider.py
@@ -646,11 +646,14 @@ class ScopedSession(base.ScopedSession):
         """
         See :py:meth:`.base.ScopedSession.delete_machine`.
         """
+        caas_machine = True if machine.previsioned_by_caas and machine.previsioned_by_caas == 1 else False
+
         machine = machine.id if isinstance(machine, dto.Machine) else machine
         self._log("Deleting machine '%s'", machine)
         # First, delete any associated ports
-        for port in self._connection.network.ports.all(device_id = machine):
-            port._delete()
+        if not caas_machine:
+            for port in self._connection.network.ports.all(device_id = machine):
+                port._delete()
         self._connection.compute.servers.delete(machine)
         try:
             return self.find_machine(machine)


### PR DESCRIPTION
Added `provisioned_by_caas` metadata. That is checked before ports are deleted.